### PR TITLE
DDBLM-17 - Minor adjustments

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,17 +1,30 @@
 {
-  "plugins": ["@babel/plugin-proposal-optional-chaining", "@babel/plugin-transform-runtime"],
+  "plugins": [
+    "@babel/plugin-proposal-optional-chaining",
+    "@babel/plugin-transform-runtime"
+  ],
   "presets": ["@babel/preset-env", "@babel/preset-react"],
   "env": {
     "production": {
-      "plugins": ["transform-react-remove-prop-types"]
+      "plugins": [
+        [
+          "transform-react-remove-prop-types",
+          {
+            "additionalLibraries": ["url-prop-type"]
+          }
+        ]
+      ]
     },
     "test": {
       "presets": [
-        ["@babel/preset-env", {
-          "targets": {
-            "node": "current"
+        [
+          "@babel/preset-env",
+          {
+            "targets": {
+              "node": "current"
+            }
           }
-        }]
+        ]
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
-    "react-error-boundary": "^1.2.5"
+    "react-error-boundary": "^1.2.5",
+    "url-prop-type": "^1.2.3"
   }
 }

--- a/src/apps/checklist/checklist.dev.jsx
+++ b/src/apps/checklist/checklist.dev.jsx
@@ -21,6 +21,7 @@ export function Entry() {
       )}
       removeButtonText={text("Remove button text", "Fjern fra listen")}
       emptyListText={text("Empty list text", "Ingen elementer på listen")}
+      errorText={text("Error text", "Et eller andet git galt.")}
     />
   );
 }

--- a/src/apps/checklist/checklist.dev.jsx
+++ b/src/apps/checklist/checklist.dev.jsx
@@ -20,8 +20,8 @@ export function Entry() {
         'https://lollandbib.dk/search/ting/phrase.creator=":author"'
       )}
       removeButtonText={text("Remove button text", "Fjern fra listen")}
-      emptyListText={text("Empty list text", "Ingen elementer på listen")}
-      errorText={text("Error text", "Et eller andet git galt.")}
+      emptyListText={text("Empty list text", "Ingen materialer på listen")}
+      errorText={text("Error text", "Et eller andet gik galt.")}
     />
   );
 }

--- a/src/apps/checklist/checklist.dev.jsx
+++ b/src/apps/checklist/checklist.dev.jsx
@@ -20,6 +20,7 @@ export function Entry() {
         'https://lollandbib.dk/search/ting/phrase.creator=":author"'
       )}
       removeButtonText={text("Remove button text", "Fjern fra listen")}
+      emptyListText={text("Empty list text", "Ingen elementer på listen")}
     />
   );
 }

--- a/src/apps/checklist/checklist.entry.jsx
+++ b/src/apps/checklist/checklist.entry.jsx
@@ -122,7 +122,7 @@ ChecklistEntry.propTypes = {
 ChecklistEntry.defaultProps = {
   removeButtonText: "Fjern fra listen",
   emptyListText: "Listen er tom",
-  errorText: "Noget git galt"
+  errorText: "Noget gik galt"
 };
 
 export default ChecklistEntry;

--- a/src/apps/checklist/checklist.entry.jsx
+++ b/src/apps/checklist/checklist.entry.jsx
@@ -19,7 +19,7 @@ function formatResult(item) {
   return {
     ...item,
     pid: item.pid?.[0],
-    creator: item.dcCreator ? item.dcCreator : item.creator,
+    creators: item.dcCreator ? item.dcCreator : item.creator,
     title: item.dcTitleFull?.[0],
     type: item.typeBibDKType?.[0],
     year: item.date?.[0],

--- a/src/apps/checklist/checklist.entry.jsx
+++ b/src/apps/checklist/checklist.entry.jsx
@@ -34,7 +34,8 @@ function ChecklistEntry({
   materialUrl,
   authorUrl,
   removeButtonText,
-  emptyListText
+  emptyListText,
+  errorText
 }) {
   const [list, setList] = useState([]);
   const [loading, setLoading] = useState("inactive");
@@ -62,7 +63,11 @@ function ChecklistEntry({
         setList(result.map(formatResult));
       })
       .catch(function onError() {
-        setList([]);
+        setLoading("failed");
+        setTimeout(() => {
+          setLoading("inactive");
+          setList([]);
+        }, 2000);
       })
       .finally(function onEnd() {
         setLoading("finished");
@@ -83,7 +88,9 @@ function ChecklistEntry({
       })
     );
     client.deleteListMaterial({ materialId }).catch(function onError() {
+      setLoading("failed");
       setTimeout(function onRestore() {
+        setLoading("inactive");
         setList(fallbackList);
       }, 2000);
     });
@@ -97,6 +104,7 @@ function ChecklistEntry({
       authorUrl={authorUrl}
       removeButtonText={removeButtonText}
       emptyListText={emptyListText}
+      errorText={errorText}
     />
   );
 }
@@ -105,12 +113,14 @@ ChecklistEntry.propTypes = {
   materialUrl: PropTypes.string.isRequired,
   authorUrl: PropTypes.string.isRequired,
   removeButtonText: PropTypes.string,
-  emptyListText: PropTypes.string
+  emptyListText: PropTypes.string,
+  errorText: PropTypes.string
 };
 
 ChecklistEntry.defaultProps = {
   removeButtonText: "Fjern fra listen",
-  emptyListText: "Listen er tom"
+  emptyListText: "Listen er tom",
+  errorText: "Noget git galt"
 };
 
 export default ChecklistEntry;

--- a/src/apps/checklist/checklist.entry.jsx
+++ b/src/apps/checklist/checklist.entry.jsx
@@ -23,7 +23,7 @@ function formatResult(item) {
     title: item.dcTitleFull?.[0],
     type: item.typeBibDKType?.[0],
     year: item.date?.[0],
-    cover: item.coverUrlThumbnail?.[0]
+    coverUrl: item.coverUrlThumbnail?.[0]
   };
 }
 

--- a/src/apps/checklist/checklist.entry.jsx
+++ b/src/apps/checklist/checklist.entry.jsx
@@ -30,7 +30,12 @@ function formatResult(item) {
  * @memberof ChecklistEntry
  * @returns {ReactNode}
  */
-function ChecklistEntry({ materialUrl, authorUrl, removeButtonText }) {
+function ChecklistEntry({
+  materialUrl,
+  authorUrl,
+  removeButtonText,
+  emptyListText
+}) {
   const [list, setList] = useState([]);
   const [loading, setLoading] = useState("inactive");
 
@@ -91,6 +96,7 @@ function ChecklistEntry({ materialUrl, authorUrl, removeButtonText }) {
       materialUrl={materialUrl}
       authorUrl={authorUrl}
       removeButtonText={removeButtonText}
+      emptyListText={emptyListText}
     />
   );
 }
@@ -98,11 +104,13 @@ function ChecklistEntry({ materialUrl, authorUrl, removeButtonText }) {
 ChecklistEntry.propTypes = {
   materialUrl: PropTypes.string.isRequired,
   authorUrl: PropTypes.string.isRequired,
-  removeButtonText: PropTypes.string
+  removeButtonText: PropTypes.string,
+  emptyListText: PropTypes.string
 };
 
 ChecklistEntry.defaultProps = {
-  removeButtonText: "Fjern fra listen"
+  removeButtonText: "Fjern fra listen",
+  emptyListText: "Listen er tom"
 };
 
 export default ChecklistEntry;

--- a/src/apps/checklist/checklist.entry.jsx
+++ b/src/apps/checklist/checklist.entry.jsx
@@ -18,10 +18,12 @@ const client = new MaterialList();
 function formatResult(item) {
   return {
     ...item,
+    pid: item.pid?.[0],
     creator: item.dcCreator ? item.dcCreator : item.creator,
-    title: item.dcTitleFull,
-    type: item.typeBibDKType,
-    year: item.date
+    title: item.dcTitleFull?.[0],
+    type: item.typeBibDKType?.[0],
+    year: item.date?.[0],
+    cover: item.coverUrlThumbnail?.[0]
   };
 }
 

--- a/src/apps/checklist/checklist.jsx
+++ b/src/apps/checklist/checklist.jsx
@@ -38,7 +38,8 @@ function Checklist({
   onRemove,
   materialUrl,
   authorUrl,
-  removeButtonText
+  removeButtonText,
+  emptyListText
 }) {
   if (loading === "active") {
     return (
@@ -49,7 +50,7 @@ function Checklist({
   }
 
   if (loading === "finished" && items.length === 0) {
-    return <Alert type="polite" message="No items on the list!" />;
+    return <Alert type="polite" message={emptyListText} />;
   }
 
   return (
@@ -118,8 +119,7 @@ function Checklist({
 
 Checklist.defaultProps = {
   items: [],
-  loading: "inactive",
-  removeButtonText: "Fjern fra listen"
+  loading: "inactive"
 };
 
 Checklist.propTypes = {
@@ -135,7 +135,8 @@ Checklist.propTypes = {
   onRemove: PropTypes.func.isRequired,
   materialUrl: PropTypes.string.isRequired,
   authorUrl: PropTypes.string.isRequired,
-  removeButtonText: PropTypes.string
+  removeButtonText: PropTypes.string.isRequired,
+  emptyListText: PropTypes.string.isRequired
 };
 
 export default Checklist;

--- a/src/apps/checklist/checklist.jsx
+++ b/src/apps/checklist/checklist.jsx
@@ -39,8 +39,13 @@ function Checklist({
   materialUrl,
   authorUrl,
   removeButtonText,
-  emptyListText
+  emptyListText,
+  errorText
 }) {
+  if (loading === "failed") {
+    return <Alert type="assertive" message={errorText} />;
+  }
+
   if (loading === "active") {
     return (
       <UnorderedList className="ddb-skeleton-wrapper">
@@ -123,7 +128,7 @@ Checklist.defaultProps = {
 };
 
 Checklist.propTypes = {
-  loading: PropTypes.oneOf(["inactive", "active", "finished"]),
+  loading: PropTypes.oneOf(["inactive", "active", "finished", "failed"]),
   items: PropTypes.arrayOf(
     PropTypes.shape({
       creator: PropTypes.string,
@@ -136,7 +141,8 @@ Checklist.propTypes = {
   materialUrl: PropTypes.string.isRequired,
   authorUrl: PropTypes.string.isRequired,
   removeButtonText: PropTypes.string.isRequired,
-  emptyListText: PropTypes.string.isRequired
+  emptyListText: PropTypes.string.isRequired,
+  errorText: PropTypes.string.isRequired
 };
 
 export default Checklist;

--- a/src/apps/checklist/checklist.jsx
+++ b/src/apps/checklist/checklist.jsx
@@ -10,9 +10,9 @@ function getList(length) {
   return Array.from(new Array(length));
 }
 
-function SkeletonElement() {
+function SkeletonElement(_, index) {
   return (
-    <li className="ddb-list__item">
+    <li key={index} className="ddb-list__item">
       <section className="ddb-list__inner">
         <article className="ddb-list__content">
           <figure className="ddb-list__cover">
@@ -89,7 +89,7 @@ function Checklist({
                 <p>
                   {item.creator.map((creator, index) => {
                     return (
-                      <span>
+                      <span key={creator}>
                         <a
                           href={createPath({
                             url: authorUrl,

--- a/src/apps/checklist/checklist.jsx
+++ b/src/apps/checklist/checklist.jsx
@@ -72,7 +72,7 @@ function Checklist({
                     value: item.pid
                   })}
                 >
-                  <img src={item.coverUrlThumbnail} alt={item.title} />
+                  <img src={item.cover} alt={item.title} />
                 </a>
               </figure>
               <div className="ddb-list__data">
@@ -131,10 +131,12 @@ Checklist.propTypes = {
   loading: PropTypes.oneOf(["inactive", "active", "finished", "failed"]),
   items: PropTypes.arrayOf(
     PropTypes.shape({
-      creator: PropTypes.string,
+      pid: PropTypes.string,
+      creator: PropTypes.arrayOf(PropTypes.string),
       title: PropTypes.string,
       type: PropTypes.string,
-      year: PropTypes.number
+      year: PropTypes.string,
+      cover: PropTypes.string
     })
   ),
   onRemove: PropTypes.func.isRequired,

--- a/src/apps/checklist/checklist.jsx
+++ b/src/apps/checklist/checklist.jsx
@@ -87,7 +87,7 @@ function Checklist({
                   <h2>{item.title}</h2>
                 </a>
                 <p>
-                  {item.creator.map((creator, index) => {
+                  {item.creators.map((creator, index) => {
                     return (
                       <span key={creator}>
                         <a
@@ -132,7 +132,7 @@ Checklist.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.shape({
       pid: PropTypes.string,
-      creator: PropTypes.arrayOf(PropTypes.string),
+      creators: PropTypes.arrayOf(PropTypes.string),
       title: PropTypes.string,
       type: PropTypes.string,
       year: PropTypes.string,

--- a/src/apps/checklist/checklist.jsx
+++ b/src/apps/checklist/checklist.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import urlPropType from "url-prop-type";
 import Skeleton from "../../components/atoms/skeleton/skeleton";
 import Button from "../../components/atoms/button/button";
 import UnorderedList from "../../components/atoms/list/list";
@@ -72,7 +73,7 @@ function Checklist({
                     value: item.pid
                   })}
                 >
-                  <img src={item.cover} alt={item.title} />
+                  <img src={item.coverUrl} alt={item.title} />
                 </a>
               </figure>
               <div className="ddb-list__data">
@@ -136,7 +137,7 @@ Checklist.propTypes = {
       title: PropTypes.string,
       type: PropTypes.string,
       year: PropTypes.string,
-      cover: PropTypes.string
+      coverUrl: urlPropType
     })
   ),
   onRemove: PropTypes.func.isRequired,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6916,6 +6916,11 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
+is-url@^1.2.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
+
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -12239,6 +12244,13 @@ url-parse@^1.4.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+url-prop-type@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/url-prop-type/-/url-prop-type-1.2.3.tgz#de6881670925570ea566cfa58ae1d3833a57aab7"
+  integrity sha512-ln+PDureVz9UNBCLo0krQJJ6h+1mmF6nB/gyc8V/Lpd1tK/rHb2BI2sVlSTMJb55E7WL6cuIxyYWgfLaa+JVbA==
+  dependencies:
+    is-url "^1.2.2"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
__Pass down empty list text.__
Besides that we also set the actual checklist to have it's texts to be required.
This way we do not need to declare the same default props.

__Add error for failed remove.__
We did not declare the error to the user. Only added the old list back.

__Flatten the imported Work.__
This makes for easier utilization in the actual list implementation.

__Fix key bug.__
We were missing some key assign that React was yelling about.