### PR TITLE
Return an empty array.

### DIFF
--- a/src/apps/checklist/checklist.entry.jsx
+++ b/src/apps/checklist/checklist.entry.jsx
@@ -47,19 +47,22 @@ function ChecklistEntry({
     client
       .getList()
       .then(function onResult(result) {
-        const op = new OpenPlatform();
-        return op.getWork({
-          pids: result,
-          fields: [
-            "dcTitleFull",
-            "pid",
-            "coverUrlThumbnail",
-            "dcCreator",
-            "creator",
-            "typeBibDKType",
-            "date"
-          ]
-        });
+        if (result && result.length) {
+          const op = new OpenPlatform();
+          return op.getWork({
+            pids: result,
+            fields: [
+              "dcTitleFull",
+              "pid",
+              "coverUrlThumbnail",
+              "dcCreator",
+              "creator",
+              "typeBibDKType",
+              "date"
+            ]
+          });
+        }
+        return [];
       })
       .then(result => {
         setList(result.map(formatResult));


### PR DESCRIPTION
If there is no materials to be found don't make a request for OpenPlatform.

This would return a 400 status code which results in an error from OpenPlatform.js. Which I do still think is correct behavior. If we do not have any pids we should not try and connect to OP and if we have invalid pids that can't be found an error should pop.