### PR TITLE
Rename successLink to successLinkUrl for Add-to-searchlist app

### DIFF
--- a/src/apps/add-to-searchlist/add-to-searchlist.dev.jsx
+++ b/src/apps/add-to-searchlist/add-to-searchlist.dev.jsx
@@ -17,7 +17,10 @@ export function Entry() {
       defaultTitle={text("Default title", "")}
       errorText={text("Error text", "Det gik galt")}
       successText={text("Success text", "Tilføjet til dine gemte søgninger.")}
-      successLink={text("Success link", "/?path=/story/apps-searchlist--entry")}
+      successLinkUrl={text(
+        "Success link URL",
+        "/?path=/story/apps-searchlist--entry"
+      )}
       successLinkText={text("Success link text", "Se dine gemte søgnigner.")}
       addButtonText={text("Add button text", "Gem")}
       helpText={text(

--- a/src/apps/add-to-searchlist/add-to-searchlist.entry.jsx
+++ b/src/apps/add-to-searchlist/add-to-searchlist.entry.jsx
@@ -14,7 +14,7 @@ function AddToSearchlistEntry({
   defaultTitle,
   helpText,
   successText,
-  successLink,
+  successLinkUrl,
   successLinkText,
   errorText,
   addButtonText,
@@ -54,7 +54,7 @@ function AddToSearchlistEntry({
       defaultTitle={defaultTitle}
       errorText={errorText}
       successText={successText}
-      successLink={successLink}
+      successLinkUrl={successLinkUrl}
       successLinkText={successLinkText}
       addButtonText={addButtonText}
       helpText={helpText}
@@ -69,7 +69,7 @@ AddToSearchlistEntry.propTypes = {
   buttonText: PropTypes.string,
   errorText: PropTypes.string,
   successText: PropTypes.string,
-  successLink: urlPropType,
+  successLinkUrl: urlPropType,
   successLinkText: PropTypes.string,
   labelText: PropTypes.string,
   addButtonText: PropTypes.string,
@@ -86,7 +86,7 @@ AddToSearchlistEntry.defaultProps = {
   labelText: "Søgetitel",
   errorText: "Noget gik galt",
   successText: "Tilføjet til dine gemte søgninger.",
-  successLink: undefined,
+  successLinkUrl: undefined,
   successLinkText: "Se dine gemte søgnigner.",
   errorRequiredMessage: "En titel er påkrævet.",
   errorMaxLengthMessage: "Titlen må ikke være længere end 255 tegn.",

--- a/src/apps/add-to-searchlist/add-to-searchlist.jsx
+++ b/src/apps/add-to-searchlist/add-to-searchlist.jsx
@@ -22,7 +22,7 @@ function AddToSearchlist({
   helpText,
   errorText,
   successText,
-  successLink,
+  successLinkUrl,
   successLinkText,
   errorRequiredMessage,
   errorMaxLengthMessage,
@@ -41,7 +41,7 @@ function AddToSearchlist({
   const success = (
     <div className="ddb-add-to-searchlist__success">
       <Alert message={successText} type="polite" variant="blank" />
-      {successLink && <a href={successLink}>{successLinkText}</a>}
+      {successLinkUrl && <a href={successLinkUrl}>{successLinkText}</a>}
     </div>
   );
 
@@ -126,7 +126,7 @@ AddToSearchlist.propTypes = {
   buttonText: PropTypes.string.isRequired,
   errorText: PropTypes.string.isRequired,
   successText: PropTypes.string.isRequired,
-  successLink: urlPropType.isRequired,
+  successLinkUrl: urlPropType.isRequired,
   successLinkText: PropTypes.string.isRequired,
   errorRequiredMessage: PropTypes.string.isRequired,
   errorMaxLengthMessage: PropTypes.string.isRequired,

--- a/src/apps/add-to-searchlist/add-to-searchlist.test.jsx
+++ b/src/apps/add-to-searchlist/add-to-searchlist.test.jsx
@@ -10,7 +10,7 @@ test("Addition to list without token", async () => {
       buttonText="Tilføj til mine søgninger"
       successText="Tilføjet til dine gemte søgninger."
       errorText="Det gik galt."
-      successLink="/?path=/story/apps-searchlist--entry"
+      successLinkUrl="/?path=/story/apps-searchlist--entry"
       successLinkText="Se dine gemte søgnigner."
       labelText="Søgetitel"
       addButtonText="Gem"


### PR DESCRIPTION
By using the Url suffix we make the naming consistent with other 
props containing urls.