### PR TITLE
Fix application mounting on IE11

### DIFF
--- a/src/core/mount.js
+++ b/src/core/mount.js
@@ -12,7 +12,7 @@ import ErrorBoundary from "../components/alert/alert";
  */
 function mount(context) {
   if (!context) return;
-  const appContainers = context.querySelectorAll("[data-ddb-app]");
+  const appContainers = [...context.querySelectorAll("[data-ddb-app]")];
   appContainers.forEach(function mountApp(container) {
     const appName = container?.dataset?.ddbApp;
     const app = window.ddbReact?.apps?.[appName];
@@ -36,7 +36,7 @@ function mount(context) {
  */
 function unMount(context) {
   if (!context) return;
-  const appContainers = context.querySelectorAll("[data-ddb-app]");
+  const appContainers = [...context.querySelectorAll("[data-ddb-app]")];
   appContainers.forEach(function unMountApp(container) {
     const appContainerToUnmount = container;
     appContainerToUnmount.innerHTML = "";


### PR DESCRIPTION
IE 11 does not support foreach on NodeLists. Convert results to
arrays.

![Dashboard 2020-01-07 12-00-48](https://user-images.githubusercontent.com/73966/71927499-e92ab600-3195-11ea-930b-a148831b6b49.png)

[According to Stack Overflow this is the common pattern with ES6](https://stackoverflow.com/questions/53331180/babel-polyfill-being-included-but-foreach-still-doesnt-work-in-ie11-on-nodelis).

I would prefer a solution which either:

1. Used a Babel Polyfill to modify the code appropriately.
2. Raised a warning during linting.

It does not seem that simple though.

