### PR TITLE
Handle retrieval of more than 20 works from OpenPlatform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 dist
 dev
 cypress/videos/apps
+cypress/screenshots/apps
 coverage
 .nyc_output
 index.html

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@reach/auto-id": "^0.6.1",
     "@reach/dialog": "^0.5.4",
     "dayjs": "^1.8.17",
+    "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",

--- a/src/core/OpenPlatform.js
+++ b/src/core/OpenPlatform.js
@@ -41,6 +41,21 @@ class OpenPlatform {
    * @memberof OpenPlatform
    */
   async getWork({ pids = [], fields = ["title"] } = {}) {
+    // OpenPlatform allows retrieval of a maximum of 20 pids per request.
+    // Recursively call this function with a subset respecting the limit and
+    // merge the results.
+    const pidLimit = 20;
+    if (pids.length > pidLimit) {
+      const subset = pids.slice(0, pidLimit);
+      const rest = pids.slice(pidLimit);
+      return Promise.all([
+        this.getWork({ pids: subset, fields }),
+        this.getWork({ pids: rest, fields })
+      ]).then(function mergeResults(results) {
+        return [].concat(...results);
+      });
+    }
+
     const formattedPids = formatPids(pids);
     const formattedFields = fields.map(encodeURIComponent).join(",");
     const getWorkUrl = `${this.baseUrl}/work?access_token=${this.token}&fields=${formattedFields}&pids=${formattedPids}`;


### PR DESCRIPTION
This limit is mentioned in the API spec at 
https://openplatform.dbc.dk/v3/ as “You should at most look up 20 ids
per API call.” In practice requests containing a higher number leads
results in error responses.

Recursively call `getWork()` to retrieve 20 works at a time and merge 
the results as the response.

<img width="836" alt="Apps | Checklist - Entry ⋅ Storybook 2020-01-07 22-48-32" src="https://user-images.githubusercontent.com/73966/71932348-02386480-31a0-11ea-9bc7-aedd80bb336d.png">
