### PR TITLE
Include Promise polyfill for IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,7 +14,8 @@
             "corejs": {
               "version": 3,
               "proposals": true
-            }
+            },
+            "include": ["es.promise"]
           }
         ]
       ],

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: Integration test
     if: '!github.event.deleted'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@master
       - name: Setup Node
@@ -35,7 +35,7 @@ jobs:
           start: yarn start:storybook:test
           wait-on: 'http://localhost:57021'
           browser: chrome
-      - name: Upload coverage to Codecov  
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,7 +71,7 @@ jobs:
   test:
     name: Integration test
     if: '!github.event.deleted'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@master
       - name: Setup Node


### PR DESCRIPTION
Add ES Promise polypill in Babel Preset Env configuration.

We are currently experiencing issues with Promise being undefined in
IE11. This might fix the problem.