### PR TITLE
ie 11 promise polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,8 +14,7 @@
             "corejs": {
               "version": 3,
               "proposals": true
-            },
-            "include": ["es.promise"]
+            }
           }
         ]
       ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,8 @@
           "webpack.config.js",
           "postcss.config.js",
           "cypress/plugins/index.js",
-          "cypress/support/index.js"
+          "cypress/support/index.js",
+          "src/core/polyfills.js"
         ]
       }
     ]

--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ A simple naive example of the required artifacts needed looks like this:
     
     <!-- Load order og scripts is of importance here -->
     <script src="/dist/runtime.js"></script>
+    <script src="/dist/polyfills.js"></script>
     <script src="/dist/bundle.js"></script>
     <script src="/dist/mount.js"></script>
     <!-- After the necesssary scripts you can start loading applications -->

--- a/src/core/polyfills.js
+++ b/src/core/polyfills.js
@@ -1,0 +1,1 @@
+import "core-js/features/promise";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,8 @@ module.exports = (_env, argv) => {
   return {
     entry: {
       ...entry,
-      mount: "./src/core/mount.js"
+      mount: "./src/core/mount.js",
+      polyfills: "./src/core/polyfills.js"
     },
     output: {
       filename: "[name].js",


### PR DESCRIPTION
Another stab at polyfilling for IE11.

This time we do it as a separate file.

When build the polyfills.js bundle is no larger than 160 bytes or so. That seems weird to me. This might be a reference thing. We should try importing it as described in the updated readme but also after the bundle.js if it indeed a reference thing.