### PR TITLE
Add support for injecting service urls through props

### DIFF
--- a/src/apps/add-to-checklist/add-to-checklist.dev.jsx
+++ b/src/apps/add-to-checklist/add-to-checklist.dev.jsx
@@ -10,6 +10,10 @@ export default {
 export function Entry() {
   return (
     <AddToChecklist
+      materialListUrl={text(
+        "MaterialList URL",
+        "https://test.materiallist.dandigbib.org"
+      )}
       text={text("Text", "Tilføj til din huskeliste")}
       errorText={text("Error text", "Der opstod en fejl")}
       successText={text("Success text", "Tilføjet")}

--- a/src/apps/add-to-checklist/add-to-checklist.entry.jsx
+++ b/src/apps/add-to-checklist/add-to-checklist.entry.jsx
@@ -5,13 +5,20 @@ import urlPropType from "url-prop-type";
 import AddToChecklist from "./add-to-checklist";
 import MaterialList from "../../core/MaterialList";
 
-const client = new MaterialList();
-
-function AddToChecklistEntry({ text, successText, errorText, id, loginUrl }) {
+function AddToChecklistEntry({
+  materialListUrl,
+  text,
+  successText,
+  errorText,
+  id,
+  loginUrl
+}) {
   const [loading, setLoading] = useState("inactive");
 
   function addToList() {
     setLoading("active");
+
+    const client = new MaterialList({ baseUrl: materialListUrl });
     client.addListMaterial({ materialId: id }).catch(function onError() {
       setLoading("failed");
       setTimeout(function onRestore() {
@@ -34,6 +41,7 @@ function AddToChecklistEntry({ text, successText, errorText, id, loginUrl }) {
 }
 
 AddToChecklistEntry.propTypes = {
+  materialListUrl: urlPropType,
   text: PropTypes.string,
   errorText: PropTypes.string,
   successText: PropTypes.string,
@@ -42,6 +50,7 @@ AddToChecklistEntry.propTypes = {
 };
 
 AddToChecklistEntry.defaultProps = {
+  materialListUrl: "https://test.materiallist.dandigbib.org",
   text: "Tilføj til min liste",
   errorText: "Det lykkedes ikke at gemme materialet.",
   successText: "Materialet er tilføjet"

--- a/src/apps/add-to-searchlist/add-to-searchlist.dev.jsx
+++ b/src/apps/add-to-searchlist/add-to-searchlist.dev.jsx
@@ -11,6 +11,10 @@ export default {
 export function Entry() {
   return (
     <AddToSearchlist
+      followSearchesUrl={text(
+        "FollowSearches URL",
+        "https://stage.followsearches.dandigbib.org"
+      )}
       searchQuery={text("Search query", "star wars")}
       buttonText={text("Button text", "Tilføj til mine søgninger")}
       labelText={text("Label text", "Søgetitel")}

--- a/src/apps/add-to-searchlist/add-to-searchlist.entry.jsx
+++ b/src/apps/add-to-searchlist/add-to-searchlist.entry.jsx
@@ -5,9 +5,8 @@ import urlPropType from "url-prop-type";
 import AddToSearchlist from "./add-to-searchlist";
 import FollowSearches from "../../core/FollowSearches";
 
-const client = new FollowSearches();
-
 function AddToSearchlistEntry({
+  followSearchesUrl,
   searchQuery,
   buttonText,
   labelText,
@@ -28,6 +27,8 @@ function AddToSearchlistEntry({
 
   function addToSearchList(title) {
     setAppState("requesting");
+
+    const client = new FollowSearches({ baseUrl: followSearchesUrl });
     client
       .addSearch({ title, query: searchQuery })
       .then(function onSuccess() {
@@ -66,6 +67,7 @@ function AddToSearchlistEntry({
 }
 
 AddToSearchlistEntry.propTypes = {
+  followSearchesUrl: urlPropType,
   buttonText: PropTypes.string,
   errorText: PropTypes.string,
   successText: PropTypes.string,
@@ -82,6 +84,7 @@ AddToSearchlistEntry.propTypes = {
 };
 
 AddToSearchlistEntry.defaultProps = {
+  followSearchesUrl: "https://stage.followsearches.dandigbib.org",
   buttonText: "Tilføj til mine søgninger",
   labelText: "Søgetitel",
   errorText: "Noget gik galt",

--- a/src/apps/checklist/checklist.dev.jsx
+++ b/src/apps/checklist/checklist.dev.jsx
@@ -11,6 +11,10 @@ export default {
 export function Entry() {
   return (
     <Checklist
+      materialListUrl={text(
+        "MaterialList URL",
+        "https://test.materiallist.dandigbib.org"
+      )}
       materialUrl={text(
         "Material URL",
         "https://lollandbib.dk/ting/object/:pid"

--- a/src/apps/checklist/checklist.entry.jsx
+++ b/src/apps/checklist/checklist.entry.jsx
@@ -6,14 +6,13 @@ import MaterialList from "../../core/MaterialList";
 import OpenPlatform from "../../core/OpenPlatform";
 import Material from "../../core/Material";
 
-const client = new MaterialList();
-
 /**
  * @param {object} - object with the URL for the material and author URL.
  * @memberof ChecklistEntry
  * @returns {ReactNode}
  */
 function ChecklistEntry({
+  materialListUrl,
   materialUrl,
   authorUrl,
   coverServiceUrl,
@@ -25,35 +24,40 @@ function ChecklistEntry({
   const [list, setList] = useState([]);
   const [loading, setLoading] = useState("inactive");
 
-  useEffect(function getList() {
-    setLoading("active");
-    client
-      .getList()
-      .then(function onResult(result) {
-        if (result && result.length) {
-          const op = new OpenPlatform();
-          return op.getWork({
-            pids: result,
-            fields: [
-              "dcTitleFull",
-              "pid",
-              "dcCreator",
-              "creator",
-              "typeBibDKType",
-              "date"
-            ]
-          });
-        }
-        return [];
-      })
-      .then(result => {
-        setLoading("finished");
-        setList(result.map(Material.format));
-      })
-      .catch(function onError() {
-        setLoading("failed");
-      });
-  }, []);
+  useEffect(
+    function getList() {
+      setLoading("active");
+
+      const client = new MaterialList({ baseUrl: materialListUrl });
+      client
+        .getList()
+        .then(function onResult(result) {
+          if (result && result.length) {
+            const op = new OpenPlatform();
+            return op.getWork({
+              pids: result,
+              fields: [
+                "dcTitleFull",
+                "pid",
+                "dcCreator",
+                "creator",
+                "typeBibDKType",
+                "date"
+              ]
+            });
+          }
+          return [];
+        })
+        .then(result => {
+          setLoading("finished");
+          setList(result.map(Material.format));
+        })
+        .catch(function onError() {
+          setLoading("failed");
+        });
+    },
+    [materialListUrl]
+  );
 
   /**
    * Function to remove a material from the list.
@@ -68,6 +72,7 @@ function ChecklistEntry({
         return item.pid !== materialId;
       })
     );
+    const client = new MaterialList({ baseUrl: materialListUrl });
     client.deleteListMaterial({ materialId }).catch(function onError() {
       setLoading("failed");
       setTimeout(function onRestore() {
@@ -93,6 +98,7 @@ function ChecklistEntry({
 }
 
 ChecklistEntry.propTypes = {
+  materialListUrl: urlPropType,
   materialUrl: urlPropType.isRequired,
   authorUrl: urlPropType.isRequired,
   coverServiceUrl: urlPropType.isRequired,
@@ -103,6 +109,7 @@ ChecklistEntry.propTypes = {
 };
 
 ChecklistEntry.defaultProps = {
+  materialListUrl: "https://test.materiallist.dandigbib.org",
   removeButtonText: "Fjern fra listen",
   emptyListText: "Listen er tom",
   errorText: "Noget gik galt",

--- a/src/apps/searchlist/searchlist.dev.jsx
+++ b/src/apps/searchlist/searchlist.dev.jsx
@@ -8,6 +8,10 @@ export default { title: "Apps|Searchlist" };
 export function Entry() {
   return (
     <Searchlist
+      followSearchesUrl={text(
+        "FollowSearches URL",
+        "https://stage.followsearches.dandigbib.org"
+      )}
       searchUrl={text("Search URL", "https://lollandbib.dk/search/ting/:query")}
     />
   );

--- a/src/apps/searchlist/searchlist.entry.jsx
+++ b/src/apps/searchlist/searchlist.entry.jsx
@@ -5,9 +5,8 @@ import urlPropType from "url-prop-type";
 import Searchlist from "./searchlist";
 import FollowSearches from "../../core/FollowSearches";
 
-const client = new FollowSearches();
-
 function SearchlistEntry({
+  followSearchesUrl,
   removeButtonText,
   emptyListText,
   errorText,
@@ -16,22 +15,30 @@ function SearchlistEntry({
 }) {
   const [searches, setSearches] = useState([]);
   const [loading, setLoading] = useState("inactive");
-  useEffect(function getSearches() {
-    setLoading("active");
-    client
-      .getSearches()
-      .then(function onSuccess(result) {
-        setSearches(result);
-        setLoading("finished");
-      })
-      .catch(function onError() {
-        setLoading("failed");
-      });
-  }, []);
+
+  useEffect(
+    function getSearches() {
+      setLoading("active");
+
+      const client = new FollowSearches({ baseUrl: followSearchesUrl });
+      client
+        .getSearches()
+        .then(function onSuccess(result) {
+          setSearches(result);
+          setLoading("finished");
+        })
+        .catch(function onError() {
+          setLoading("failed");
+        });
+    },
+    [followSearchesUrl]
+  );
 
   function removeSearch(id) {
     const fallback = [...searches];
     setSearches(searches.filter(search => search.id !== id));
+
+    const client = new FollowSearches({ baseUrl: followSearchesUrl });
     client.deleteSearch({ searchId: id }).catch(function onError() {
       setSearches(fallback);
     });
@@ -52,6 +59,7 @@ function SearchlistEntry({
 }
 
 SearchlistEntry.propTypes = {
+  followSearchesUrl: urlPropType,
   removeButtonText: PropTypes.string,
   errorText: PropTypes.string,
   emptyListText: PropTypes.string,
@@ -60,6 +68,7 @@ SearchlistEntry.propTypes = {
 };
 
 SearchlistEntry.defaultProps = {
+  followSearchesUrl: "https://stage.followsearches.dandigbib.org",
   removeButtonText: "Fjern fra listen",
   emptyListText: "Ingen gemte søgninger.",
   errorText: "Gemte søgninger kunne ikke hentes.",

--- a/src/core/FollowSearches.js
+++ b/src/core/FollowSearches.js
@@ -18,9 +18,9 @@ import { getToken } from "./token";
  * @class FollowSearches
  */
 class FollowSearches {
-  constructor() {
+  constructor({ baseUrl }) {
     this.token = getToken();
-    this.baseUrl = "https://stage.followsearches.dandigbib.org";
+    this.baseUrl = baseUrl;
   }
 
   /**

--- a/src/core/MaterialList.js
+++ b/src/core/MaterialList.js
@@ -7,9 +7,9 @@ import { getToken } from "./token";
  * @class MaterialList
  */
 class MaterialList {
-  constructor() {
+  constructor({ baseUrl }) {
     this.token = getToken();
-    this.baseUrl = "https://test.materiallist.dandigbib.org";
+    this.baseUrl = baseUrl;
   }
 
   /**


### PR DESCRIPTION
This will allow users of our components to determine which service
they want to integrate with e.g. for switching between staging and
production versions of the service.

By using props we are using the same approach as we use for other
customizations. To retain current behavior the urls default to 
non-production versions.

For this to work we have to move service instance creation inside our
hooks. This is a bit less elegant but if we only move in inside our
Component function React will keep rerendering the components.

Add a knob for controlling service urls in the Storybook.