### PR TITLE
DDBLM-72 - Cover service

### DIFF
--- a/src/apps/checklist/checklist.dev.jsx
+++ b/src/apps/checklist/checklist.dev.jsx
@@ -19,6 +19,10 @@ export function Entry() {
         "Author URL",
         'https://lollandbib.dk/search/ting/phrase.creator=":author"'
       )}
+      coverServiceUrl={text(
+        "Cover Service URL",
+        "https://cover.dandigbib.org/api"
+      )}
       removeButtonText={text("Remove button text", "Fjern fra listen")}
       emptyListText={text("Empty list text", "Ingen materialer på listen")}
       errorText={text("Error text", "Et eller andet gik galt.")}

--- a/src/apps/checklist/checklist.entry.jsx
+++ b/src/apps/checklist/checklist.entry.jsx
@@ -16,6 +16,7 @@ const client = new MaterialList();
 function ChecklistEntry({
   materialUrl,
   authorUrl,
+  coverServiceUrl,
   removeButtonText,
   emptyListText,
   errorText,
@@ -83,6 +84,7 @@ function ChecklistEntry({
       onRemove={onRemove}
       materialUrl={materialUrl}
       authorUrl={authorUrl}
+      coverServiceUrl={coverServiceUrl}
       removeButtonText={removeButtonText}
       emptyListText={emptyListText}
       errorText={errorText}
@@ -94,6 +96,7 @@ function ChecklistEntry({
 ChecklistEntry.propTypes = {
   materialUrl: urlPropType.isRequired,
   authorUrl: urlPropType.isRequired,
+  coverServiceUrl: urlPropType.isRequired,
   removeButtonText: PropTypes.string,
   emptyListText: PropTypes.string,
   errorText: PropTypes.string,

--- a/src/apps/checklist/checklist.jsx
+++ b/src/apps/checklist/checklist.jsx
@@ -24,6 +24,7 @@ function Checklist({
   onRemove,
   materialUrl,
   authorUrl,
+  coverServiceUrl,
   removeButtonText,
   emptyListText,
   errorText,
@@ -61,6 +62,7 @@ function Checklist({
             item={item}
             materialUrl={materialUrl}
             authorUrl={authorUrl}
+            coverServiceUrl={coverServiceUrl}
             ofText={ofText}
             dataClass="ddb-checklist__data"
           />
@@ -90,6 +92,7 @@ Checklist.propTypes = {
   onRemove: PropTypes.func.isRequired,
   materialUrl: PropTypes.string.isRequired,
   authorUrl: PropTypes.string.isRequired,
+  coverServiceUrl: PropTypes.string.isRequired,
   removeButtonText: PropTypes.string.isRequired,
   emptyListText: PropTypes.string.isRequired,
   errorText: PropTypes.string.isRequired,

--- a/src/components/cover/cover.jsx
+++ b/src/components/cover/cover.jsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import CoverService from "../../core/CoverService";
+import Skeleton from "../atoms/skeleton/skeleton";
+
+export function CoverSkeleton({ className }) {
+  return (
+    <Skeleton
+      className={className}
+      br="0px"
+      mb="0px"
+      mt="0px"
+      height="154px"
+      width="100px"
+    />
+  );
+}
+
+CoverSkeleton.defaultProps = {
+  className: ""
+};
+
+CoverSkeleton.propTypes = {
+  className: PropTypes.string
+};
+
+function Cover({
+  id,
+  format,
+  size,
+  idType,
+  generic,
+  alt,
+  coverClassName,
+  className,
+  coverServiceUrl
+}) {
+  const [src, setSrc] = useState(null);
+  useEffect(() => {
+    const coverClient = new CoverService({
+      baseUrl: coverServiceUrl
+    });
+    coverClient
+      .getCover({ id, size: [size], format: [format], idType, generic })
+      .then(response => setSrc(response));
+  }, [id, format, size, idType, generic, coverServiceUrl]);
+
+  return src ? (
+    <img className={className} src={src} alt={alt} />
+  ) : (
+    <CoverSkeleton className={coverClassName} />
+  );
+}
+
+Cover.defaultProps = {
+  idType: "pid",
+  format: "jpeg",
+  size: "default",
+  generic: true,
+  coverClassName: "",
+  className: ""
+};
+
+Cover.propTypes = {
+  id: PropTypes.string.isRequired,
+  alt: PropTypes.string.isRequired,
+  idType: PropTypes.oneOf(["faust", "isbn", "issn", "pid"]),
+  format: PropTypes.oneOf(["jpeg", "png"]),
+  size: PropTypes.oneOf(["default", "original", "thumbnail"]),
+  generic: PropTypes.bool,
+  className: PropTypes.string,
+  coverClassName: PropTypes.string,
+  coverServiceUrl: PropTypes.string.isRequired
+};
+
+export default Cover;

--- a/src/components/cover/cover.jsx
+++ b/src/components/cover/cover.jsx
@@ -1,7 +1,46 @@
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
+import urlPropType from "url-prop-type";
 import CoverService from "../../core/CoverService";
 import Skeleton from "../atoms/skeleton/skeleton";
+
+export const COVER_EMPTY = "empty";
+export const COVER_INITIAL = "initial";
+
+/**
+ * A custom hook that retrives a cover image.
+ *
+ * @export
+ * @param {object} options
+ * @param {string} options.id
+ * @param {string} options.format
+ * @param {string} options.size
+ * @param {string} options.idType
+ * @param {boolean} options.generic
+ * @param {string} options.coverServiceUrl
+ *
+ * @returns either an "initial", "empty" or actual src status.
+ */
+export function useCover({
+  id,
+  format = "jpeg",
+  size = "default",
+  idType = "pid",
+  generic = false,
+  coverServiceUrl = "https://cover.dandigbib.org/api"
+}) {
+  const [status, setStatus] = useState(COVER_INITIAL);
+  useEffect(() => {
+    const coverClient = new CoverService({
+      baseUrl: coverServiceUrl
+    });
+    coverClient
+      .getCover({ id, size: [size], format: [format], idType, generic })
+      .then(response => setStatus(response))
+      .catch(() => setStatus(COVER_EMPTY));
+  }, [id, format, size, idType, generic, coverServiceUrl]);
+  return status || COVER_EMPTY;
+}
 
 export function CoverSkeleton({ className }) {
   return (
@@ -24,53 +63,30 @@ CoverSkeleton.propTypes = {
   className: PropTypes.string
 };
 
-function Cover({
-  id,
-  format,
-  size,
-  idType,
-  generic,
-  alt,
-  coverClassName,
-  className,
-  coverServiceUrl
-}) {
-  const [src, setSrc] = useState(null);
-  useEffect(() => {
-    const coverClient = new CoverService({
-      baseUrl: coverServiceUrl
-    });
-    coverClient
-      .getCover({ id, size: [size], format: [format], idType, generic })
-      .then(response => setSrc(response));
-  }, [id, format, size, idType, generic, coverServiceUrl]);
-
-  return src ? (
-    <img className={className} src={src} alt={alt} />
-  ) : (
-    <CoverSkeleton className={coverClassName} />
-  );
+function Cover({ src, alt, coverClassName, className }) {
+  if (src === COVER_INITIAL) {
+    return <CoverSkeleton className={coverClassName} />;
+  }
+  if (src === COVER_EMPTY) {
+    return null;
+  }
+  return <img className={className} src={src} alt={alt} />;
 }
 
 Cover.defaultProps = {
-  idType: "pid",
-  format: "jpeg",
-  size: "default",
-  generic: true,
   coverClassName: "",
-  className: ""
+  className: "",
+  src: "initial"
 };
 
 Cover.propTypes = {
-  id: PropTypes.string.isRequired,
   alt: PropTypes.string.isRequired,
-  idType: PropTypes.oneOf(["faust", "isbn", "issn", "pid"]),
-  format: PropTypes.oneOf(["jpeg", "png"]),
-  size: PropTypes.oneOf(["default", "original", "thumbnail"]),
-  generic: PropTypes.bool,
+  src: PropTypes.oneOfType([
+    PropTypes.oneOf(["initial", "empty"]),
+    urlPropType
+  ]),
   className: PropTypes.string,
-  coverClassName: PropTypes.string,
-  coverServiceUrl: PropTypes.string.isRequired
+  coverClassName: PropTypes.string
 };
 
 export default Cover;

--- a/src/components/simple-material/simple-material.dev.jsx
+++ b/src/components/simple-material/simple-material.dev.jsx
@@ -11,7 +11,6 @@ export function Base() {
   return (
     <SimpleMaterial
       item={{
-        coverUrl: text("Cover", "https://source.unsplash.com/random/165x235"),
         creators: array("Creators", ["Pablo Hidalgo"]),
         pid: text("pid", "870970-basis:52836913"),
         title: text(
@@ -29,6 +28,10 @@ export function Base() {
       authorUrl={text(
         "Author URL",
         'https://lollandbib.dk/search/ting/phrase.creator=":author"'
+      )}
+      coverServiceUrl={text(
+        "Cover Service URL",
+        "https://cover.dandigbib.org/api"
       )}
     />
   );

--- a/src/components/simple-material/simple-material.jsx
+++ b/src/components/simple-material/simple-material.jsx
@@ -3,12 +3,13 @@ import PropTypes from "prop-types";
 import urlPropType from "url-prop-type";
 import replacePlaceholders from "../../core/replacePlaceholders";
 import Skeleton from "../atoms/skeleton/skeleton";
+import Cover, { CoverSkeleton, useCover, COVER_EMPTY } from "../cover/cover";
 
 export function SimpleMaterialSkeleton({ style }) {
   return (
     <div className="ddb-simple-material-skeleton" style={style}>
       <figure className="ddb-reset">
-        <Skeleton br="0px" mb="0px" mt="0px" height="154px" width="100px" />
+        <CoverSkeleton />
       </figure>
       <div>
         <Skeleton width="45px" mb="12px" />
@@ -31,14 +32,16 @@ function SimpleMaterial({
   item,
   materialUrl,
   authorUrl,
+  coverServiceUrl,
   ofText,
   className,
   dataClass,
   style
 }) {
+  const coverStatus = useCover({ id: item.pid, coverServiceUrl });
   return (
     <section className={`ddb-simple-material ${className}`} style={style}>
-      {item.coverUrl && (
+      {coverStatus !== COVER_EMPTY && (
         <figure className="ddb-simple-material__cover">
           <a
             href={replacePlaceholders({
@@ -48,7 +51,7 @@ function SimpleMaterial({
               }
             })}
           >
-            <img src={item.coverUrl} alt={item.title} />
+            <Cover src={coverStatus} alt={item.title} />
           </a>
         </figure>
       )}
@@ -106,13 +109,13 @@ SimpleMaterial.propTypes = {
   dataClass: PropTypes.string,
   materialUrl: urlPropType.isRequired,
   authorUrl: urlPropType.isRequired,
+  coverServiceUrl: urlPropType.isRequired,
   item: PropTypes.shape({
     pid: PropTypes.string.isRequired,
     creators: PropTypes.arrayOf(PropTypes.string),
     title: PropTypes.string,
     type: PropTypes.string,
-    year: PropTypes.string,
-    coverUrl: urlPropType
+    year: PropTypes.string
   }).isRequired,
   style: PropTypes.objectOf(PropTypes.any)
 };

--- a/src/core/CoverService.js
+++ b/src/core/CoverService.js
@@ -1,0 +1,69 @@
+import fetch from "unfetch";
+import { getToken } from "./token";
+
+/**
+ * https://cover.dandigbib.org/api/
+ *
+ * @class CoverService
+ */
+class CoverService {
+  /**
+   *Creates an instance of CoverService.
+   * @param {object} options
+   * @param {string} options.baseUrl
+   * @memberof CoverService
+   */
+  constructor({ baseUrl }) {
+    this.token = getToken();
+    this.baseUrl = baseUrl;
+  }
+
+  /**
+   * Get a cover for a a material provided it's id.
+   *
+   * @param {object} options
+   * @param {string} options.id the actual id of the material.
+   * @param {string} options.idType a material can have a multitude of id's of different types.
+   * @param {string} options.format which format to return the image in.
+   * @param {string} options.size the relative size of the image to be returned.
+   * @param {boolean} options.generic if placeholders should be returned for the image if no image exists.
+   *
+   * @returns {string} requested cover as an url string
+   * @memberof CoverService
+   */
+  async getCover({
+    id,
+    idType = "pid",
+    format = ["jpeg"],
+    size = ["default"],
+    generic = true
+  }) {
+    if (!id) {
+      throw Error("id must be specified");
+    }
+    const base = `${this.baseUrl}/cover/${idType}/${encodeURIComponent(id)}`;
+    const formattedFormat = format.join(",");
+    const formattedSize = size.join(",");
+    const url = `${base}?format=${formattedFormat},&size=${formattedSize},&generic=${generic.toString()}`;
+    const raw = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${this.token}`
+      }
+    });
+    if (raw.status !== 200) {
+      throw Error(raw.status);
+    }
+    const response = await raw.json();
+    // TODO: this filtering will be refactored when the service actually
+    // returns whats asked of it.
+    const finalImage = response.imageUrls.filter(
+      image =>
+        format.some(currentFormat => image.format === currentFormat) &&
+        size.some(currentSize => image.size === currentSize)
+    );
+    return finalImage?.[0]?.url;
+  }
+}
+
+export default CoverService;


### PR DESCRIPTION
![load_images](https://user-images.githubusercontent.com/2671660/73222565-d9363e80-4163-11ea-8cd6-2e7bd61e7ade.gif)

The Cover inhabits it's own Skeleton that is now used in multiple places and is also responsible for it's own fetching of it's image component.

CoverService is a small abstraction around the API endpoint.

getCover is supposed to return just a flat single string. Made the most sense for the use case. Might want to extend that further down the line.

It's still just a simple image tag but instead of providing the coverUrl from the item we now fetch it independently.

Context has also been used here so we did not have to pass down the serviceUrl all the way from the entry. This might be taken further and a text context is easy to imagine.