### PR TITLE
Add object.values polyfill

### DIFF
--- a/src/core/polyfills.js
+++ b/src/core/polyfills.js
@@ -1,2 +1,3 @@
 import "core-js/features/promise";
 import "core-js/features/array/find";
+import "core-js/features/object/values";


### PR DESCRIPTION
The method currently fails when trying to save a search in IE11.

![Dashboard 2020-01-28 16-12-37](https://user-images.githubusercontent.com/73966/73276656-55269a00-41e9-11ea-8755-9b547c4327c6.png)
