### PR TITLE
Remove OpenPlatform coverThumbnailUrl

### DIFF
--- a/src/apps/checklist/checklist.entry.jsx
+++ b/src/apps/checklist/checklist.entry.jsx
@@ -37,7 +37,6 @@ function ChecklistEntry({
             fields: [
               "dcTitleFull",
               "pid",
-              "coverUrlThumbnail",
               "dcCreator",
               "creator",
               "typeBibDKType",

--- a/src/apps/checklist/checklist.test.js
+++ b/src/apps/checklist/checklist.test.js
@@ -24,8 +24,7 @@ describe("Checklist", () => {
             dcCreator: ["Jason Fry"],
             dcTitleFull: ["Star Wars - the last Jedi"],
             typeBibDKType: ["Bog"],
-            date: ["2018"],
-            coverUrlThumbnail: ["https://source.unsplash.com/random/165x235"]
+            date: ["2018"]
           }
         ]
       }
@@ -58,8 +57,7 @@ describe("Checklist", () => {
             dcCreator: ["Jason Fry"],
             dcTitleFull: ["Star Wars - the last Jedi"],
             typeBibDKType: ["Bog"],
-            date: ["2018"],
-            coverUrlThumbnail: ["https://source.unsplash.com/random/165x235"]
+            date: ["2018"]
           }
         ]
       }
@@ -97,8 +95,7 @@ describe("Checklist", () => {
             dcCreator: ["Jason Fry"],
             dcTitleFull: ["Star Wars - the last Jedi"],
             typeBibDKType: ["Bog"],
-            date: ["2018"],
-            coverUrlThumbnail: ["https://source.unsplash.com/random/165x235"]
+            date: ["2018"]
           }
         ]
       }
@@ -173,8 +170,7 @@ describe("Checklist", () => {
               // Include id in title so we have something to match against.
               dcTitleFull: [`Material ${id}`],
               typeBibDKType: ["Type"],
-              date: ["2018"],
-              coverUrlThumbnail: ["https://source.unsplash.com/random/165x235"]
+              date: ["2018"]
             };
           })
         }

--- a/src/core/Material.js
+++ b/src/core/Material.js
@@ -16,8 +16,7 @@ class Material {
       creators: raw.dcCreator ? raw.dcCreator : raw.creator,
       title: raw.dcTitleFull?.[0],
       type: raw.typeBibDKType?.[0],
-      year: raw.date?.[0],
-      coverUrl: raw.coverUrlThumbnail?.[0]
+      year: raw.date?.[0]
     };
   }
 }


### PR DESCRIPTION
We use the Cover service instead so there is no reason to fetch it.

Update tests accordingly