### PR TITLE
Fix list content sizing in IE11

### DIFF
--- a/src/apps/checklist/checklist.scss
+++ b/src/apps/checklist/checklist.scss
@@ -4,7 +4,7 @@
   }
 
   &__data {
-    width: auto;
-    max-width: unset;
+    width: 100%;
+    max-width: none;
   }
 }


### PR DESCRIPTION
In the current form list items with long titels have a very long
which may overlap with the buttons to the right.

This probably has to do with the fact that we use unset for max-width
which is not supported by IE11. If we set it to none all items will
be too wide.

This is then addressed by setting max-width to 100% instead of auto.

Before:

![Dashboard 2020-02-03 15-07-28](https://user-images.githubusercontent.com/73966/73660119-dd98b500-4697-11ea-9526-4df8a3641ef4.png)

After:

![Dashboard 2020-02-03 15-09-00](https://user-images.githubusercontent.com/73966/73660128-e4272c80-4697-11ea-8f24-72993405bbef.png)

