### PR TITLE
Control timing in test using Cypres clock

### DIFF
--- a/src/apps/add-to-searchlist/add-to-searchlist.test.js
+++ b/src/apps/add-to-searchlist/add-to-searchlist.test.js
@@ -20,13 +20,12 @@ describe("Add to Searchlist", () => {
 
   it("Submit and wait for auto close", () => {
     cy.visit("/iframe.html?id=apps-add-to-searchlist--entry");
+    cy.clock();
     cy.contains("Tilføj til mine søgninger").click();
     cy.get('input[placeholder*="Søgetitel"]').type("Min søgning");
     cy.contains("button", "Gem").click();
     cy.contains("Tilføjet til dine gemte søgninger.");
-    // We want to wait for the timeout to finish.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(10000);
+    cy.tick(10000);
     cy.contains("Tilføj til mine søgninger");
   });
 
@@ -54,6 +53,7 @@ describe("Add to Searchlist", () => {
       response: {}
     });
     cy.visit("/iframe.html?id=apps-add-to-searchlist--entry");
+    cy.clock();
     cy.contains("Tilføj til mine søgninger").click();
     cy.get("form")
       .find("input")
@@ -61,9 +61,7 @@ describe("Add to Searchlist", () => {
       .type("Min søgning");
     cy.contains("button", "Gem").click();
     cy.contains("Det gik galt");
-    // We want to wait for the timeout to finish.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000);
+    cy.tick(2000);
     cy.contains("Tilføj til mine søgninger");
   });
 });

--- a/src/apps/checklist/checklist.test.js
+++ b/src/apps/checklist/checklist.test.js
@@ -107,12 +107,11 @@ describe("Checklist", () => {
       response: {}
     });
     cy.visit("/iframe.html?id=apps-checklist--entry");
+    cy.clock();
     cy.contains("Star Wars - the last Jedi");
     cy.contains("Fjern fra listen").click();
     cy.contains("Et eller andet gik galt.");
-    // We want to wait for the timeout to finish.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000);
+    cy.tick(2000);
     cy.contains("Star Wars - the last Jedi");
     cy.contains("Ingen materialer på listen").should("not.be.visible");
   });


### PR DESCRIPTION
This could make timing more reliable and our tests will run faster
if they do not have to actually wait for time to elapse.

See https://docs.cypress.io/api/commands/clock.html#Syntax