### PR TITLE
Use in-memory storage of tokens

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,10 +1,16 @@
 import { configure } from '@storybook/react';
 import './dev-fonts.scss';
 import '../src/components/components.scss';
-import getToken, { setToken } from '../src/core/token';
+import { setToken } from '../src/core/token';
 import "../src/core/mount";
 
-let token = getToken();
+/**
+ * DDB_TOKEN is set in ".storybook/webpack.config.js"
+ * Look for it in DefinePlugin.
+ */
+const tokenKey = "ddb-token";
+let token = localStorage.getItem(tokenKey) || DDB_TOKEN;
+
 if (!token) {
   // We do not want to keep prompting people if they have already cancelled the prompt once.
   const seenKey = 'ddb-token-prompt-seen';
@@ -14,15 +20,13 @@ if (!token) {
     token = window.prompt("Do you have a token for Adgangsplatformen? Input it here.");
     if (token === null) { // which means the prompt has been cancelled
       localStorage.setItem(seenKey, "seen");
+    } else {
+      localStorage.setItem(tokenKey, token);
     }
   }
 }
 
-/**
- * DDB_TOKEN is set in ".storybook/webpack.config.js"
- * Look for it in DefinePlugin.
- */
-setToken(token || DDB_TOKEN);
+setToken(token);
 
 /**
  * This emulates the way we would set from the server that a user is authenticated aka. logged in.

--- a/README.md
+++ b/README.md
@@ -397,11 +397,8 @@ A simple naive example of the required artifacts needed looks like this:
     <!-- After the necesssary scripts you can start loading applications -->
     <script src="/dist/add-to-checklist.js"></script>
     <script>
-      // For making successfull requests to the different services we need a valid token
-      // to be stored in localStorage of the client browser.
-      // The key should be "ddb-token".
-      // This is only for local testing. Not in production environments.
-      window.localStorage.setItem("ddb-token", "XXXXXXXXXXXXXXXXXXXXXX");
+      // For making successfull requests to the different services we need a valid token.
+     window.ddbReact.setToken("XXXXXXXXXXXXXXXXXXXXXX");
 
       // If this function isn't called no apps will display.
       // An app will only be displayed if there is a container for it

--- a/src/core/mount.js
+++ b/src/core/mount.js
@@ -3,6 +3,7 @@ import { render } from "react-dom";
 
 import { withErrorBoundary } from "react-error-boundary";
 import ErrorBoundary from "../components/alert/alert";
+import { setToken } from "./token";
 
 /**
  * We look for containers and corresponding applications.
@@ -46,6 +47,7 @@ function unMount(context) {
 function init() {
   const initial = {
     apps: {},
+    setToken,
     mount,
     unMount
   };

--- a/src/core/token.js
+++ b/src/core/token.js
@@ -1,31 +1,25 @@
-const TOKEN_KEY = "ddb-token";
+let currentToken;
 
 /**
- * Primarily for development purposes.
  * We want to set a token we can use for the different services.
  *
  * @param {string} token
  * @export
  */
 export function setToken(token) {
-  const storedToken = localStorage.getItem(TOKEN_KEY);
-  if (!storedToken && token) {
-    localStorage.setItem(TOKEN_KEY, token);
-  }
+  currentToken = token;
 }
 
 /**
  * Initialize the getToken closure.
  * Will return a memorized getToken function that in turn
- * returns a token, either from memory or from localStorage.
+ * returns a token.
  *
  * @returns {function}
  */
 function initToken() {
-  let token;
   return function getToken() {
-    if (token) return token;
-    return localStorage.getItem(TOKEN_KEY);
+    return currentToken;
   };
 }
 


### PR DESCRIPTION
The key point is that sites using this library need to call
setToken - or window.ddbReact.setToken - to make the applications
use a certain token. How that token is stored is up to the individual
site.

Update documentation accordingly.