### PR TITLE
Remove empty objects from OpenPlatform work responses

### DIFF
--- a/src/core/OpenPlatform.js
+++ b/src/core/OpenPlatform.js
@@ -1,4 +1,5 @@
 import chunk from "lodash/chunk";
+import isEmpty from "lodash/isEmpty";
 import fetch from "unfetch";
 import { getToken } from "./token";
 
@@ -65,7 +66,10 @@ class OpenPlatform {
     if (response.statusCode !== 200) throw Error(response.error);
     if (!response.data) throw Error("data not found");
 
-    return response.data;
+    const rawResults = response.data;
+    // Remove empty objects which OpenPlatform may returned for pids which have
+    // no corresponding meta data.
+    return rawResults.filter(result => !isEmpty(result));
   }
 }
 


### PR DESCRIPTION
OpenPlatform may return empty objects for materials which have no
corresponding metadata. They end up looking weird in the checklist.

In general we are not interested in processing such objects so remove
them from the response. It is an exercise for the caller to determine
which if any requested pids have not yielded corresponding meta data.

The current situation:
![Apps | Checklist - Entry ⋅ Storybook 2020-02-04 22-42-26](https://user-images.githubusercontent.com/73966/73789770-ad3c3e00-479f-11ea-8985-f4d81b1981c5.png)