### PR TITLE
Rework Cover url/status

### DIFF
--- a/src/components/cover/cover.dev.jsx
+++ b/src/components/cover/cover.dev.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { withKnobs, text } from "@storybook/addon-knobs";
+import Cover from "./cover";
+
+export default {
+  title: "Atoms|Cover",
+  decorators: [withKnobs]
+};
+
+export function Base() {
+  return (
+    <Cover
+      status="retrieved"
+      src={text(
+        "Image url",
+        "https://upload.wikimedia.org/wikipedia/en/7/7f/Star_Wars_The_Last_Jedi.jpg"
+      )}
+      alt={text("Alternative text", "Value")}
+      className={text("Class name", "")}
+      coverClassName={text("Cover image class name", "")}
+    />
+  );
+}
+
+export function Initial() {
+  return (
+    <Cover
+      status="initial"
+      alt={text("Alternative text", "Loading...")}
+      coverClassName={text("Cover image class name", "")}
+    />
+  );
+}

--- a/src/components/simple-material/simple-material.jsx
+++ b/src/components/simple-material/simple-material.jsx
@@ -38,10 +38,10 @@ function SimpleMaterial({
   dataClass,
   style
 }) {
-  const coverStatus = useCover({ id: item.pid, coverServiceUrl });
+  const cover = useCover({ id: item.pid, coverServiceUrl });
   return (
     <section className={`ddb-simple-material ${className}`} style={style}>
-      {coverStatus !== COVER_EMPTY && (
+      {cover.status !== COVER_EMPTY && (
         <figure className="ddb-simple-material__cover">
           <a
             href={replacePlaceholders({
@@ -51,7 +51,7 @@ function SimpleMaterial({
               }
             })}
           >
-            <Cover src={coverStatus} alt={item.title} />
+            <Cover status={cover.status} src={cover.url} alt={item.title} />
           </a>
         </figure>
       )}


### PR DESCRIPTION
 Split cover url and status into separate properties.

This makes the code more readable compared to the current situation
where we assign variables named status to properties named src etc.

Also add storybook for Cover atom while we are at it.