### PR TITLE
Allow Codecov to fail

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -39,4 +39,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -112,4 +112,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
The Codecov uploader requires a token which is typically stored in a
GitHub secret within the repository. However these secrets are not 
used for PRs of forks. This causes upload and thus our entire build
to fail.

Codecov seems to be working on tokenless uploads but there is no good
way to solve this at the moment. Allow Codecov to fail while we wait.

https://github.com/codecov/codecov-action/issues/29#issuecomment-581540357