### PR TITLE
Fix unmount casing

### DIFF
--- a/src/core/mount.js
+++ b/src/core/mount.js
@@ -35,7 +35,7 @@ function mount(context) {
  *
  * @param {HTMLElement} context - The HTML element you want to search for app containers in.
  */
-function unMount(context) {
+function unmount(context) {
   if (!context) return;
   const appContainers = context.querySelectorAll("[data-ddb-app]");
   appContainers.forEach(function unMountApp(container) {
@@ -49,7 +49,7 @@ function init() {
     apps: {},
     setToken,
     mount,
-    unMount
+    unmount
   };
   window.ddbReact = {
     ...(window.ddbReact || {}),


### PR DESCRIPTION
[Our only user at the moment calls `window.ddbReact.unmount()` - not
`window.ddbReact.unMount()`](https://github.com/ding2/ding2/blob/master/modules/ding_react/js/ding-react.js#L31). One has to give.

Unmount is an actual word so there is no need to use special casing
here. Consequently we rename `unMount` to `unmount`.