### PR TITLE
Use small cover size on checklist

### DIFF
--- a/src/apps/checklist/checklist.jsx
+++ b/src/apps/checklist/checklist.jsx
@@ -60,6 +60,7 @@ function Checklist({
         >
           <SimpleMaterial
             item={item}
+            coverSize="small"
             materialUrl={materialUrl}
             authorUrl={authorUrl}
             coverServiceUrl={coverServiceUrl}

--- a/src/components/cover/cover.jsx
+++ b/src/components/cover/cover.jsx
@@ -26,7 +26,7 @@ export const COVER_INITIAL = "initial";
  * @param {object} options
  * @param {string} options.id
  * @param {string} options.format
- * @param {string} options.size
+ * @param {('default'|'small'|'medium'|'large'|'original')}  options.size
  * @param {string} options.idType
  * @param {boolean} options.generic
  * @param {string} options.coverServiceUrl

--- a/src/components/simple-material/simple-material.dev.jsx
+++ b/src/components/simple-material/simple-material.dev.jsx
@@ -20,6 +20,7 @@ export function Base() {
         type: text("Type", "Bog"),
         year: text("Year", "2016")
       }}
+      coverSize={text("Cover size", "small")}
       ofText={text("ofText", "Af")}
       materialUrl={text(
         "Material URL",

--- a/src/components/simple-material/simple-material.jsx
+++ b/src/components/simple-material/simple-material.jsx
@@ -30,6 +30,7 @@ SimpleMaterialSkeleton.defaultProps = {
 
 function SimpleMaterial({
   item,
+  coverSize,
   materialUrl,
   authorUrl,
   coverServiceUrl,
@@ -38,7 +39,7 @@ function SimpleMaterial({
   dataClass,
   style
 }) {
-  const cover = useCover({ id: item.pid, coverServiceUrl });
+  const cover = useCover({ id: item.pid, size: coverSize, coverServiceUrl });
   return (
     <section className={`ddb-simple-material ${className}`} style={style}>
       {cover.status !== COVER_EMPTY && (
@@ -110,6 +111,13 @@ SimpleMaterial.propTypes = {
   materialUrl: urlPropType.isRequired,
   authorUrl: urlPropType.isRequired,
   coverServiceUrl: urlPropType.isRequired,
+  coverSize: PropTypes.oneOf([
+    "original",
+    "default",
+    "small",
+    "medium",
+    "large"
+  ]),
   item: PropTypes.shape({
     pid: PropTypes.string.isRequired,
     creators: PropTypes.arrayOf(PropTypes.string),
@@ -121,6 +129,7 @@ SimpleMaterial.propTypes = {
 };
 
 SimpleMaterial.defaultProps = {
+  coverSize: "small",
   ofText: "Af",
   className: "",
   dataClass: "",


### PR DESCRIPTION
Cover sizes are not documented on https://cover.dandigbib.org/api yet but
we know from [reliable sources](danskernesdigitalebibliotek/ddb-cover-service@c032871#diff-9d7dfaab874f37cb5053b6ed4a75c933R582-R585) that the service supports the sizes
`small`, `medium`, `large` in addition to `default` and `original`.

Add cover size prop for simple materials. We use small on checklist and in general also default to small as that size matches our current base styling.

Update StoryBook with additional knob to match.

