### PR TITLE
Make storybook user authenticated status dependent on token

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,7 @@
-import { configure } from '@storybook/react';
-import './dev-fonts.scss';
-import '../src/components/components.scss';
-import { setToken } from '../src/core/token';
+import { configure } from "@storybook/react";
+import "./dev-fonts.scss";
+import "../src/components/components.scss";
+import { setToken } from "../src/core/token";
 import "../src/core/mount";
 
 /**
@@ -13,12 +13,15 @@ let token = localStorage.getItem(tokenKey) || DDB_TOKEN;
 
 if (!token) {
   // We do not want to keep prompting people if they have already cancelled the prompt once.
-  const seenKey = 'ddb-token-prompt-seen';
+  const seenKey = "ddb-token-prompt-seen";
   const promptHasBeenCancelled = localStorage.getItem(seenKey);
   if (!promptHasBeenCancelled && ENV != "test") {
     console.log(ENV);
-    token = window.prompt("Do you have a token for Adgangsplatformen? Input it here.");
-    if (token === null) { // which means the prompt has been cancelled
+    token = window.prompt(
+      "Do you have a token for Adgangsplatformen? Input it here."
+    );
+    if (token === null) {
+      // which means the prompt has been cancelled
       localStorage.setItem(seenKey, "seen");
     } else {
       localStorage.setItem(tokenKey, token);
@@ -37,4 +40,4 @@ setToken(token);
  */
 window.ddbReact.userAuthenticated = true;
 
-configure(require.context('../src', true, /\.dev\.jsx$/), module);
+configure(require.context("../src", true, /\.dev\.jsx$/), module);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -3,6 +3,7 @@ import "./dev-fonts.scss";
 import "../src/components/components.scss";
 import { setToken } from "../src/core/token";
 import "../src/core/mount";
+import isEmpty from "lodash/isEmpty";
 
 /**
  * DDB_TOKEN is set in ".storybook/webpack.config.js"
@@ -38,6 +39,6 @@ setToken(token);
  * as to not override the ddbReact object. We presume for now that if a user is in a development environment
  * they are authenticated and only in a development environment a token is available.
  */
-window.ddbReact.userAuthenticated = true;
+window.ddbReact.userAuthenticated = !isEmpty(token);
 
 configure(require.context("../src", true, /\.dev\.jsx$/), module);


### PR DESCRIPTION
Having it always set to true even if no token is available can lead
to weird situations.

Instead we base if on whether the user has actually provided a token
value or not. We cannot determine if the token actually valid as this
point.

Also: Make config.js prettier. If not then every file watcher will trigger on the file.