### PR TITLE
JIT OpenPlatform token

### DIFF
--- a/src/apps/order-material/order-material.entry.jsx
+++ b/src/apps/order-material/order-material.entry.jsx
@@ -5,8 +5,6 @@ import urlPropType from "url-prop-type";
 import OrderMaterial from "./order-material";
 import OpenPlatform from "../../core/OpenPlatform";
 
-const client = new OpenPlatform();
-
 /**
  * Transform a set of ids to an array of ids.
  *
@@ -38,6 +36,7 @@ function OrderMaterialEntry({
 
   function orderMaterial() {
     setStatus("processing");
+    const client = new OpenPlatform();
     client
       .orderMaterial({ pids: idsArray(ids), pickupBranch, expires })
       .then(function materialOrdered() {
@@ -52,6 +51,7 @@ function OrderMaterialEntry({
     function getOrderStatus() {
       setStatus("checking");
       // Check that the pickup branch accepts inter-library loans.
+      const client = new OpenPlatform();
       client
         .getBranch(pickupBranch)
         .then(function onBranchResult(branch) {

--- a/src/core/OpenPlatform.js
+++ b/src/core/OpenPlatform.js
@@ -54,7 +54,6 @@ function formatUrlArray(items = []) {
 
 class OpenPlatform {
   constructor() {
-    this.token = getToken();
     this.baseUrl = "https://openplatform.dbc.dk/v3";
   }
 
@@ -111,7 +110,7 @@ class OpenPlatform {
     const formattedFields = fields.map(encodeURIComponent).join(",");
 
     const works = await this.request(
-      `work?access_token=${this.token}&fields=${formattedFields}&pids=${formattedPids}`
+      `work?access_token=${getToken()}&fields=${formattedFields}&pids=${formattedPids}`
     );
 
     return works.filter(result => !isEmpty(result));
@@ -134,7 +133,7 @@ class OpenPlatform {
     const formattedFields = fields.map(encodeURIComponent).join(",");
 
     return this.request(
-      `availability?access_token=${this.token}&fields=${formattedFields}&pids=${formattedPids}`
+      `availability?access_token=${getToken()}&fields=${formattedFields}&pids=${formattedPids}`
     );
   }
 
@@ -181,7 +180,7 @@ class OpenPlatform {
     // that might end up in logs somewhere). But POST is still the
     // most semantically correct method to use.
     const parameters = [
-      `access_token=${this.token}`,
+      `access_token=${getToken()}`,
       "orderType=normal",
       `expires=${expires}`,
       `pickUpBranch="${pickupBranch}"`
@@ -254,7 +253,7 @@ class OpenPlatform {
    * @returns {User}
    */
   async getUser() {
-    return this.request(`user?access_token=${this.token}`);
+    return this.request(`user?access_token=${getToken()}`);
   }
 
   /**
@@ -266,7 +265,7 @@ class OpenPlatform {
    * @returns {Library[]}
    */
   async getLibraries({ agencyIds = [], branchIds = [] }) {
-    const parameters = [`access_token=${this.token}`];
+    const parameters = [`access_token=${getToken()}`];
 
     if (agencyIds.length > 0) {
       parameters.push(`agencyIds=${formatUrlArray(agencyIds)}`);


### PR DESCRIPTION
Instead of retrieving the token value once when initializing an
`OpenPlatform` object we retrieve it just in time.

This way we avoid timing issues where an object is created before the
token is set.

We use the `getToken()` function directly instead of creating another class function. It would just call `getToken()` anyway. Retrieving the token is currently a cheap operation so there is no need to ensure that it only happens once.

Also we  inline `OpenPlatform` client instance for Order material. This makes the implementation consistent with Checklist entry.



