### PR TITLE
Do not try to determine order status if user is not authenticated

### DIFF
--- a/src/apps/order-material/order-material.entry.jsx
+++ b/src/apps/order-material/order-material.entry.jsx
@@ -4,6 +4,7 @@ import urlPropType from "url-prop-type";
 
 import OrderMaterial from "./order-material";
 import OpenPlatform from "../../core/OpenPlatform";
+import User from "../../core/user";
 
 /**
  * Transform a set of ids to an array of ids.
@@ -49,6 +50,13 @@ function OrderMaterialEntry({
 
   useEffect(
     function getOrderStatus() {
+      if (!User.isAuthenticated()) {
+        // Ready is the state we use for buttons which require login when
+        // accessed by anonymous users.
+        setStatus("ready");
+        return;
+      }
+
       setStatus("checking");
       // Check that the pickup branch accepts inter-library loans.
       const client = new OpenPlatform();


### PR DESCRIPTION
We need a token for this - otherwise the request will fail.

Set the status to ready if we do not have a token to render a button
which will redirect to the login page.