### PR TITLE
Add preact as react alias.

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -27,6 +27,14 @@ module.exports = async ({ config }) => {
       include: path.resolve(__dirname, "../")
     }
   ];
+  const resolve = {
+    ...config.resolve,
+    alias: {
+      ...config.resolve.alias,
+      react: "preact/compat",
+      "react-dom": "preact/compat"
+    }
+  }
   const plugins = [
     ...config.plugins,
     new DefinePlugin({
@@ -34,5 +42,5 @@ module.exports = async ({ config }) => {
       ENV: JSON.stringify(process.env.NODE_ENV)
     })
   ]
-  return { ...config, plugins, module: { ...config.module, rules } };
+  return { ...config, plugins, resolve, module: { ...config.module, rules } };
 };

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@reach/auto-id": "^0.6.1",
     "@reach/dialog": "^0.5.4",
     "lodash": "^4.17.15",
+    "preact": "^10.3.4",
     "prop-types": "^15.7.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",

--- a/src/apps/checklist/checklist.test.js
+++ b/src/apps/checklist/checklist.test.js
@@ -107,10 +107,10 @@ describe("Checklist", () => {
       response: {}
     });
     cy.visit("/iframe.html?id=apps-checklist--entry");
-    cy.clock();
     cy.contains("Star Wars - the last Jedi");
     cy.contains("Fjern fra listen").click();
     cy.contains("Et eller andet gik galt.");
+    cy.clock();
     cy.tick(2000);
     cy.contains("Star Wars - the last Jedi");
     cy.contains("Ingen materialer på listen").should("not.be.visible");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,15 +34,19 @@ module.exports = (_env, argv) => {
     },
     mode: argv.mode,
     devtool: production ? "source-map" : "inline-source-map",
+    resolve: {
+      extensions: [".js", ".jsx", ".json"],
+      alias: {
+        react: "preact/compat",
+        "react-dom": "preact/compat"
+      }
+    },
     optimization: {
       runtimeChunk: "single",
       splitChunks: {
         name: () => "bundle",
         chunks: "all"
       }
-    },
-    resolve: {
-      extensions: [".js", ".jsx", ".json"]
     },
     module: {
       rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -10552,6 +10552,11 @@ postcss@^7.0.26:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+preact@^10.3.4:
+  version "10.3.4"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.3.4.tgz#e1542a4d3eba3e7a37f312a2c331231b97052024"
+  integrity sha512-wMgzs/RGYf0I1PZf8ZFJdyU/3kCcwepJyVYe+N9FGajyQWarMoPrPfrQajcG0psPj6ySYv2cSuLYFCihvV/Qrw==
+
 prebuild-install@^5.3.2:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.3.tgz#ef4052baac60d465f5ba6bf003c9c1de79b9da8e"


### PR DESCRIPTION
https://preactjs.com/guide/v10/differences-to-react

This reduces the `bundle.js` size from __267kB__ -> __157kB__. __~42%__ decrease.

On the surface we are still just writing react but the smaller size makes Preact desirable. As of this PR we are opting for using Preact for development as well to minimize compatibility issues when it comes to production but it is more than possible to only make use of Preact in production.

The main downside is the incoherencies we __will__ encounter along the way.
But it's a big chunk to cut off and might be worth the hassle.