### PR TITLE
Library tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ cypress/screenshots/apps
 coverage
 .nyc_output
 index.html
-.tokens
+.tokens.json
 .vscode
 yarn-error.log

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ cypress/screenshots/apps
 coverage
 .nyc_output
 index.html
-.token
+.tokens
 .vscode
 yarn-error.log

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,31 +4,49 @@ import { setToken } from "../src/core/token";
 import "../src/core/mount";
 
 /**
- * DDB_TOKEN is set in ".storybook/webpack.config.js"
- * Look for it in DefinePlugin.
+ * Environment variables are set in ".storybook/webpack.config.js:
+ * - DDB_TOKEN_USER
+ * - DDB_TOKEN_LIBRARY
+ * Look for them in DefinePlugin.
  */
-const tokenKey = "ddb-token";
-let token = localStorage.getItem(tokenKey) || DDB_TOKEN;
+const tokenConfigs = [
+  {
+    type: "user",
+    value: DDB_TOKEN_USER,
+    setValue: token => setToken("user", token)
+  },
+  {
+    type: "library",
+    value: DDB_TOKEN_LIBRARY,
+    setValue: token => setToken("library", token)
+  }
+];
 
-if (!token) {
-  // We do not want to keep prompting people if they have already cancelled the prompt once.
-  const seenKey = "ddb-token-prompt-seen";
-  const promptHasBeenCancelled = localStorage.getItem(seenKey);
-  if (!promptHasBeenCancelled && ENV != "test") {
-    console.log(ENV);
-    token = window.prompt(
-      "Do you have a token for Adgangsplatformen? Input it here."
-    );
-    if (token === null) {
-      // which means the prompt has been cancelled
-      localStorage.setItem(seenKey, "seen");
-    } else {
-      localStorage.setItem(tokenKey, token);
+tokenConfigs.forEach(function(tokenConfig) {
+  const { type, value } = tokenConfig;
+  const valueKey = `ddb-token-${type}`;
+
+  let token = localStorage.getItem(valueKey) || value;
+
+  if (!token) {
+    // We do not want to keep prompting people if they have already cancelled the prompt once.
+    const seenKey = `ddb-token-${type}-prompt-seen`;
+    const promptHasBeenCancelled = localStorage.getItem(seenKey);
+    if (!promptHasBeenCancelled && ENV != "test") {
+      token = window.prompt(
+        `Do you have a ${type} token for Adgangsplatformen? Input it here.`
+      );
+      if (token === null) {
+        // which means the prompt has been cancelled
+        localStorage.setItem(seenKey, "seen");
+      } else {
+        localStorage.setItem(valueKey, token);
+      }
     }
   }
-}
 
-setToken(token);
+  tokenConfig.setValue(token);
+});
 
 /**
  * This emulates the way we would set from the server that a user is authenticated aka. logged in.

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -47,12 +47,3 @@ tokenConfigs.forEach(function(tokenConfig) {
 
   tokenConfig.setValue(token);
 });
-
-/**
- * This emulates the way we would set from the server that a user is authenticated aka. logged in.
- * In a production/server environment this value is set before "init()" in "/src/core/mount.js" has been run.
- * In this development instance we want to set explicitly to true after the "ddbReact" object has been initialized
- * as to not override the ddbReact object. We presume for now that if a user is in a development environment
- * they are authenticated and only in a development environment a token is available.
- */
-window.ddbReact.userAuthenticated = true;

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require("path");
-const fs = require("fs").promises
-const DefinePlugin = require('webpack').DefinePlugin;
+const fs = require("fs").promises;
+const DefinePlugin = require("webpack").DefinePlugin;
 const chalk = require("chalk");
 
 const customWebpack = require("../webpack.config.js");
@@ -25,7 +25,7 @@ module.exports = async ({ config }) => {
     }
   });
 
-  const custom = customWebpack(undefined, { mode: 'development' })
+  const custom = customWebpack(undefined, { mode: "development" });
   const rules = [
     ...custom.module.rules,
     // We need to make use of css modules in our stories.
@@ -46,6 +46,6 @@ module.exports = async ({ config }) => {
         : null,
       ENV: JSON.stringify(process.env.NODE_ENV)
     })
-  ]
+  ];
   return { ...config, plugins, module: { ...config.module, rules } };
 };

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -7,15 +7,23 @@ const customWebpack = require("../webpack.config.js");
 
 // https://storybook.js.org/docs/configurations/custom-webpack-config/#full-control-mode
 module.exports = async ({ config }) => {
-  let token;
+  let tokens = {};
   try {
-    token = await fs.readFile(path.resolve(__dirname, "../.token"), "utf8");
-  } catch(err) {
-    console.warn(chalk.yellow("warn") + " => Could not find the .token file in root");
+    tokens = await fs.readFile(path.resolve(__dirname, "../.tokens"), "utf8");
+    tokens = JSON.parse(tokens);
+  } catch (err) {
+    console.warn(
+      chalk.yellow("warn") + " => Could not find the .tokens file in root"
+    );
   }
-  if (!token) {
-    console.warn(chalk.yellow("warn") + " => Token is empty. Requests to external services might not work!");
-  }
+  ["user", "library"].forEach(type => {
+    if (!tokens.hasOwnProperty(type)) {
+      console.warn(
+        chalk.yellow("warn") +
+          ` => No ${type} entry in .tokens file. Requests to external services might not work!`
+      );
+    }
+  });
 
   const custom = customWebpack(undefined, { mode: 'development' })
   const rules = [
@@ -30,7 +38,12 @@ module.exports = async ({ config }) => {
   const plugins = [
     ...config.plugins,
     new DefinePlugin({
-      DDB_TOKEN: JSON.stringify(token),
+      DDB_TOKEN_USER: tokens.hasOwnProperty("user")
+        ? JSON.stringify(tokens.user)
+        : null,
+      DDB_TOKEN_LIBRARY: tokens.hasOwnProperty("library")
+        ? JSON.stringify(tokens.library)
+        : null,
       ENV: JSON.stringify(process.env.NODE_ENV)
     })
   ]

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -9,18 +9,21 @@ const customWebpack = require("../webpack.config.js");
 module.exports = async ({ config }) => {
   let tokens = {};
   try {
-    tokens = await fs.readFile(path.resolve(__dirname, "../.tokens"), "utf8");
+    tokens = await fs.readFile(
+      path.resolve(__dirname, "../.tokens.json"),
+      "utf8"
+    );
     tokens = JSON.parse(tokens);
   } catch (err) {
     console.warn(
-      chalk.yellow("warn") + " => Could not find the .tokens file in root"
+      chalk.yellow("warn") + " => Could not find a .tokens.json file in root"
     );
   }
   ["user", "library"].forEach(type => {
     if (!tokens.hasOwnProperty(type)) {
       console.warn(
         chalk.yellow("warn") +
-          ` => No ${type} entry in .tokens file. Requests to external services might not work!`
+          ` => No ${type} entry in .tokens.json file. Requests to external services might not work!`
       );
     }
   });

--- a/README.md
+++ b/README.md
@@ -478,14 +478,6 @@ A simple naive example of the required artifacts needed looks like this:
     <!-- Data attributes will be camelCased on the react side aka. props.errorText and props.text -->
     <div data-ddb-app='add-to-checklist' data-text="Chromatic dragon" data-error-text="Minor mistake"></div>
     <div data-ddb-app='a-none-existing-app'></div>
-
-    <script>
-      // This key is not used for actual validation but merely as a way to adjust the interface accordingly.
-      // Additional keys will be injected into the "ddbReact" container object at a later stage in mount.js.
-      window.ddbReact = {
-        userAuthenticated: true // But only "true" if the user is actually authenticated.
-      }
-    </script>
     
     <!-- Load order og scripts is of importance here -->
     <script src="/dist/runtime.js"></script>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 * [make](https://www.gnu.org/software/make/)
 * [Docker](https://www.docker.com/products/docker-desktop)
 * [Dory](https://github.com/FreedomBen/dory)
-* `.tokens` file in the root of the project containing valid access tokens for a patron and a library. This is used in the communication with [OpenPlatform](https://openplatform.dbc.dk/v3/), [MaterialList](https://github.com/danskernesdigitalebibliotek/material-list) and [FollowSearches](https://github.com/danskernesdigitalebibliotek/follow-searches). ___(optional, you might not need or want live data.)___
+* `.tokens.json` file in the root of the project containing valid access tokens for a patron and a library. This is used in the communication with [OpenPlatform](https://openplatform.dbc.dk/v3/), [MaterialList](https://github.com/danskernesdigitalebibliotek/material-list) and [FollowSearches](https://github.com/danskernesdigitalebibliotek/follow-searches). ___(optional, you might not need or want live data.)___
 
 #### Retrieving access tokens
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 - [Development](#development)
   - [Requirements](#requirements)
-    - [Retrieving an access token](#retrieving-an-access-token)
+    - [Retrieving access tokens](#retrieving-access-tokens)
+      - [User tokens](#user-tokens)
+      - [Library tokens](#library-tokens)
   - [Installation](#installation)
   - [Standard and style](#standard-and-style)
     - [JavaScript + JSX](#javascript--jsx)
@@ -33,17 +35,28 @@
 * [make](https://www.gnu.org/software/make/)
 * [Docker](https://www.docker.com/products/docker-desktop)
 * [Dory](https://github.com/FreedomBen/dory)
-* `.token` file in the root of the project containing a valid Adgangsplatformen token for a patron. This is used in the communication with [OpenPlatform](https://openplatform.dbc.dk/v3/), [MaterialList](https://github.com/danskernesdigitalebibliotek/material-list) and [FollowSearches](https://github.com/danskernesdigitalebibliotek/follow-searches). ___(optional, you might not need or want live data.)___
+* `.tokens` file in the root of the project containing valid access tokens for a patron and a library. This is used in the communication with [OpenPlatform](https://openplatform.dbc.dk/v3/), [MaterialList](https://github.com/danskernesdigitalebibliotek/material-list) and [FollowSearches](https://github.com/danskernesdigitalebibliotek/follow-searches). ___(optional, you might not need or want live data.)___
 
-#### Retrieving an access token
+#### Retrieving access tokens
 
-The [OAuth access token must be retrieved from Adgangsplatformen](https://github.com/DBCDK/hejmdal/blob/master/docs/oauth2.md), a single sign-on solution for public libraries in Denmark. 
+Access token must be retrieved from [Adgangsplatformen](https://github.com/DBCDK/hejmdal/blob/master/docs/oauth2.md), a single sign-on solution for public libraries in Denmark, and [OpenPlatform](https://openplatform.dbc.dk/v3/), an API for danish libraries.
 
-Usage of Adgangsplatformen requires a valid client id and secret which must be
+Usage of these systems require a valid client id and secret which must be
 obtained from your library partner or directly from DBC, the company responsible
-for running Adgangsplatfomen.
+for running Adgangsplatfomen and OpenPlatform.
 
-Example for retrieving an access token using password grant:
+We have a make target for retrieving an access token.
+You still need the valid client id and client secret as described above.
+
+```bash
+make token
+```
+
+The following steps describe how these tokens can be retrieved manually.
+
+##### User tokens
+
+Example for retrieving an user access token from Adgangsplatformen using password grant:
 
 ```bash
 curl -X POST https://login.bib.dk/oauth/token -d 'grant_type=password&password=[patron-password]&username=[patron-username]&agency=[patron-library-agency-id]&client_id=[client-id]&client_secret=[client-secret]'
@@ -59,11 +72,22 @@ This will return a data structure containing the access token:
 }
 ```
 
-We have a make target for retrieving an access token.
-You still need the valid client id and client secret as described above.
+##### Library tokens
+
+Example for retrieving a library access token from OpenPlatform using password grant:
 
 ```bash
-make token
+curl --user "[client-id]:[client-secret]" -X POST https://auth.dbc.dk/oauth/token -d "grant_type=password&username=@DK-[library-agency-id]&password=@DK-[library-agency-id]" 
+```
+
+This will return a data structure containing the access token:
+
+```json
+{
+    "access_token":"abcd1234",
+    "token_type":"Bearer",
+    "expires_in":2591999
+}
 ```
 
 ### Installation
@@ -471,8 +495,9 @@ A simple naive example of the required artifacts needed looks like this:
     <!-- After the necesssary scripts you can start loading applications -->
     <script src="/dist/add-to-checklist.js"></script>
     <script>
-      // For making successfull requests to the different services we need a valid token.
-     window.ddbReact.setToken("XXXXXXXXXXXXXXXXXXXXXX");
+      // For making successfull requests to the different services we need one or more valid tokens.
+     window.ddbReact.setToken("user","XXXXXXXXXXXXXXXXXXXXXX");
+     window.ddbReact.setToken("library","YYYYYYYYYYYYYYYYYYYYYY");
 
       // If this function isn't called no apps will display.
       // An app will only be displayed if there is a container for it

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-loader": "^8.0.6",
     "babel-plugin-istanbul": "^5.2.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+    "base-64": "^0.1.0",
     "chalk": "^2.4.2",
     "chokidar-cli": "^2.1.0",
     "concurrently": "^5.0.0",

--- a/scripts/generateToken.js
+++ b/scripts/generateToken.js
@@ -82,14 +82,14 @@ inquirer
   })
   .then(function writeTokenFile() {
     return fs.writeFile(
-      path.resolve(__dirname, "../.tokens"),
+      path.resolve(__dirname, "../.tokens.json"),
       JSON.stringify(tokens),
       "utf8"
     );
   })
   .then(function onEnd() {
     console.info(
-      chalk.blue("!") + ".tokens file added to the root of the project."
+      chalk.blue("!") + ".tokens.json file added to the root of the project."
     );
   })
   .catch(function onError(error) {

--- a/scripts/generateToken.js
+++ b/scripts/generateToken.js
@@ -3,6 +3,10 @@ const path = require("path");
 const fetch = require("node-fetch");
 const inquirer = require("inquirer");
 const chalk = require("chalk");
+const base64 = require("base-64");
+
+let input = {};
+const tokens = {};
 
 inquirer
   .prompt([
@@ -34,34 +38,58 @@ inquirer
       type: "password"
     }
   ])
-  .then(function parseAnswers(answers) {
-    const result = Object.keys(answers).reduce((acc, key) => {
-      return `${acc}&${key}=${answers[key]}`;
-    }, "");
-    return result;
+  .then(function collectAnswers(answers) {
+    input = answers;
   })
-  .then(function fetchToken(body) {
+  .then(function fetchUserToken() {
+    const body = Object.keys(input).reduce((acc, key) => {
+      return `${acc}&${key}=${input[key]}`;
+    }, "grant_type=password");
     return fetch("https://login.bib.dk/oauth/token", {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded"
       },
-      body: `grant_type=password${body}`
+      body
     });
   })
   .then(function parseRaw(raw) {
     return raw.json();
   })
   .then(function giveFeedback(response) {
-    console.info(chalk.blue("!") + " " + response.access_token);
-    return response.access_token;
+    console.info(chalk.blue("!") + ` user token: ${response.access_token}`);
+    tokens.user = response.access_token;
   })
-  .then(function writeTokenFile(token) {
-    return fs.writeFile(path.resolve(__dirname, "../.token"), token, "utf8");
+  .then(function fetchLibraryToken() {
+    const body = `grant_type=password&username=@DK-${input.agency}&password=@DK-${input.agency}`;
+    return fetch("https://auth.dbc.dk/oauth/token", {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${base64.encode(
+          `${input.client_id}:${input.client_secret}`
+        )}`,
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body
+    });
+  })
+  .then(function parseRaw(raw) {
+    return raw.json();
+  })
+  .then(function giveFeedback(response) {
+    console.info(chalk.blue("!") + ` library token: ${response.access_token}`);
+    tokens.library = response.access_token;
+  })
+  .then(function writeTokenFile() {
+    return fs.writeFile(
+      path.resolve(__dirname, "../.tokens"),
+      JSON.stringify(tokens),
+      "utf8"
+    );
   })
   .then(function onEnd() {
     console.info(
-      chalk.blue("!") + " .token file added to the root of the project."
+      chalk.blue("!") + ".tokens file added to the root of the project."
     );
   })
   .catch(function onError(error) {

--- a/src/core/CoverService.js
+++ b/src/core/CoverService.js
@@ -14,7 +14,7 @@ class CoverService {
    * @memberof CoverService
    */
   constructor({ baseUrl }) {
-    this.token = getToken();
+    this.token = getToken("library");
     this.baseUrl = baseUrl;
   }
 

--- a/src/core/CoverService.js
+++ b/src/core/CoverService.js
@@ -14,7 +14,6 @@ class CoverService {
    * @memberof CoverService
    */
   constructor({ baseUrl }) {
-    this.token = getToken("library");
     this.baseUrl = baseUrl;
   }
 
@@ -52,7 +51,7 @@ class CoverService {
     const raw = await fetch(url, {
       headers: {
         Accept: "application/json",
-        Authorization: `Bearer ${this.token}`
+        Authorization: `Bearer ${getToken("library")}`
       }
     });
     if (raw.status !== 200) {

--- a/src/core/FollowSearches.js
+++ b/src/core/FollowSearches.js
@@ -19,7 +19,7 @@ import { getToken } from "./token";
  */
 class FollowSearches {
   constructor({ baseUrl }) {
-    this.token = getToken();
+    this.token = getToken("user");
     this.baseUrl = baseUrl;
   }
 

--- a/src/core/FollowSearches.js
+++ b/src/core/FollowSearches.js
@@ -19,7 +19,6 @@ import { getToken } from "./token";
  */
 class FollowSearches {
   constructor({ baseUrl }) {
-    this.token = getToken("user");
     this.baseUrl = baseUrl;
   }
 
@@ -49,7 +48,7 @@ class FollowSearches {
         method: "GET",
         headers: {
           Accept: "application/json",
-          Authorization: `Bearer ${this.token}`
+          Authorization: `Bearer ${getToken("user")}`
         }
       }
     );
@@ -81,7 +80,7 @@ class FollowSearches {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${this.token}`
+        Authorization: `Bearer ${getToken("user")}`
       },
       body: JSON.stringify({ title, query })
     });
@@ -116,7 +115,7 @@ class FollowSearches {
         method: "GET",
         headers: {
           Accept: "application/json",
-          Authorization: `Bearer ${this.token}`
+          Authorization: `Bearer ${getToken("user")}`
         }
       }
     );
@@ -147,7 +146,7 @@ class FollowSearches {
       {
         method: "DELETE",
         headers: {
-          Authorization: `Bearer ${this.token}`
+          Authorization: `Bearer ${getToken("user")}`
         }
       }
     );

--- a/src/core/MaterialList.js
+++ b/src/core/MaterialList.js
@@ -8,7 +8,7 @@ import { getToken } from "./token";
  */
 class MaterialList {
   constructor({ baseUrl }) {
-    this.token = getToken();
+    this.token = getToken("user");
     this.baseUrl = baseUrl;
   }
 

--- a/src/core/MaterialList.js
+++ b/src/core/MaterialList.js
@@ -8,7 +8,6 @@ import { getToken } from "./token";
  */
 class MaterialList {
   constructor({ baseUrl }) {
-    this.token = getToken("user");
     this.baseUrl = baseUrl;
   }
 
@@ -23,7 +22,7 @@ class MaterialList {
     const raw = await fetch(`${this.baseUrl}/list/${listId}`, {
       headers: {
         Accept: "application/json",
-        Authorization: `Bearer ${this.token}`
+        Authorization: `Bearer ${getToken("user")}`
       }
     });
     if (raw.status !== 200) {
@@ -51,7 +50,7 @@ class MaterialList {
       {
         method: "HEAD",
         headers: {
-          Authorization: `Bearer ${this.token}`
+          Authorization: `Bearer ${getToken("user")}`
         }
       }
     );
@@ -78,7 +77,7 @@ class MaterialList {
       {
         method: "PUT",
         headers: {
-          Authorization: `Bearer ${this.token}`
+          Authorization: `Bearer ${getToken("user")}`
         }
       }
     );
@@ -105,7 +104,7 @@ class MaterialList {
       {
         method: "DELETE",
         headers: {
-          Authorization: `Bearer ${this.token}`
+          Authorization: `Bearer ${getToken("user")}`
         }
       }
     );

--- a/src/core/OpenPlatform.js
+++ b/src/core/OpenPlatform.js
@@ -108,9 +108,10 @@ class OpenPlatform {
 
     const formattedPids = formatUrlArray(pids);
     const formattedFields = fields.map(encodeURIComponent).join(",");
+    const token = getToken("library");
 
     const works = await this.request(
-      `work?access_token=${getToken()}&fields=${formattedFields}&pids=${formattedPids}`
+      `work?access_token=${token}&fields=${formattedFields}&pids=${formattedPids}`
     );
 
     return works.filter(result => !isEmpty(result));
@@ -131,9 +132,10 @@ class OpenPlatform {
   }) {
     const formattedPids = formatUrlArray(pids);
     const formattedFields = fields.map(encodeURIComponent).join(",");
+    const token = getToken("library");
 
     return this.request(
-      `availability?access_token=${getToken()}&fields=${formattedFields}&pids=${formattedPids}`
+      `availability?access_token=${token}&fields=${formattedFields}&pids=${formattedPids}`
     );
   }
 
@@ -180,7 +182,7 @@ class OpenPlatform {
     // that might end up in logs somewhere). But POST is still the
     // most semantically correct method to use.
     const parameters = [
-      `access_token=${getToken()}`,
+      `access_token=${getToken("user")}`,
       "orderType=normal",
       `expires=${expires}`,
       `pickUpBranch="${pickupBranch}"`
@@ -254,7 +256,7 @@ class OpenPlatform {
    * @returns {User}
    */
   async getUser() {
-    return this.request(`user?access_token=${getToken()}`);
+    return this.request(`user?access_token=${getToken("user")}`);
   }
 
   /**
@@ -266,7 +268,7 @@ class OpenPlatform {
    * @returns {Library[]}
    */
   async getLibraries({ agencyIds = [], branchIds = [] }) {
-    const parameters = [`access_token=${getToken()}`];
+    const parameters = [`access_token=${getToken("library")}`];
 
     if (agencyIds.length > 0) {
       parameters.push(`agencyIds=${formatUrlArray(agencyIds)}`);
@@ -315,7 +317,7 @@ class OpenPlatform {
     if (sort) parameters.push(`sort=${sort}`);
     if (fields) parameters.push(`fields=${formatUrlArray(fields)}`);
     return this.request(
-      `search?access_token=${getToken()}&q=${encodeURIComponent(
+      `search?access_token=${getToken("library")}&q=${encodeURIComponent(
         query
       )}&offset=${offset}&${parameters.join("&")}`
     );

--- a/src/core/token.js
+++ b/src/core/token.js
@@ -1,33 +1,38 @@
-let currentToken;
+const tokens = {};
+
+/**
+ * @typedef {"user" | "library"} TokenType
+ *
+ * - library: The token represents the current library organisation. The library
+ *   may also be referred to as the agency.
+ * - user: The token represents the current library user. The user may also
+ *   be referred to as the patron.
+ *   A user token will provide at least the same access as a library token for
+ *   the library of the user but since is provides access to personal
+ *   information about the current user it must only be used for services which
+ *   have an actual need for such information. If not then use the library
+ *   token.
+ */
 
 /**
  * We want to set a token we can use for the different services.
  *
- * @param {string} token
- * @export
+ * @param {TokenType} type
+ * @param {string} value
  */
-export function setToken(token) {
-  currentToken = token;
+export function setToken(type, value) {
+  tokens[type] = value;
 }
 
 /**
- * Initialize the getToken closure.
- * Will return a memorized getToken function that in turn
- * returns a token.
+ * Returns a token.
  *
- * @returns {function}
- */
-function initToken() {
-  return function getToken() {
-    return currentToken;
-  };
-}
-
-/**
- * Returns the token.
+ * @param {TokenType} type
  *
  * @returns {string} token
  */
-export const getToken = initToken();
+export function getToken(type) {
+  return tokens[type];
+}
 
 export default getToken;

--- a/src/core/token.js
+++ b/src/core/token.js
@@ -25,6 +25,16 @@ export function setToken(type, value) {
 }
 
 /**
+ * Returns whether a token has been defined.
+ *
+ * @param {TokenType} type
+ * @returns {boolean}
+ */
+export function hasToken(type) {
+  return type in tokens;
+}
+
+/**
  * Returns a token.
  *
  * @param {TokenType} type

--- a/src/core/user.js
+++ b/src/core/user.js
@@ -3,16 +3,18 @@
  *
  * @class User
  */
+import { hasToken } from "./token";
+
 class User {
   /**
-   * Returns wheter a user is authenticated of not.
+   * Returns whether a user is authenticated of not.
    *
    * @static
    * @returns {boolean}
    * @memberof User
    */
   static isAuthenticated() {
-    return window.ddbReact?.userAuthenticated;
+    return hasToken("user");
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,6 +3574,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base-64@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+  integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
+
 base64-js@^1.0.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"


### PR DESCRIPTION
Implement support for multiple tokens: Currently user and library

We want to be able to perform some actions like showing a list of
related materials without requiring the user to sign in. OpenPlatform
supports this through generic library tokens.

To support this we expand token handling to support multiple token
types and use the appropriate type for each service.

In this proces memoization of tokens was dropped. Retrieving an object
property does not need such complexity.

Many actions like performing a search, retrieving the availability of
an object or listing library branches do not require a user while
getting your bookmarks or placing an order do.

Consequently all services are updated accordingly.

Supporting multiple keys also mean that we have to update our
surrounding tooling:

- `generateToken.js` now fetches and stores both user and library token
- the webpack configuration now loads or prompt for multiple tokens

Library authentication is a bit different than user authentication
and we have to use Basic auth so we need to include Base64 encoding
for this.

This change also allows us to remote the `userAuthenticated` entry 
from global scope. We do not really need it as we can determine whether
the user is logged in based on the availability of a user token.

