### PR TITLE
Coverservice v2

### DIFF
--- a/src/apps/checklist/checklist.dev.jsx
+++ b/src/apps/checklist/checklist.dev.jsx
@@ -25,7 +25,7 @@ export function Entry() {
       )}
       coverServiceUrl={text(
         "Cover Service URL",
-        "https://cover.dandigbib.org/api"
+        "https://cover.dandigbib.org/api/v2"
       )}
       removeButtonText={text("Remove button text", "Fjern fra listen")}
       emptyListText={text("Empty list text", "Ingen materialer på listen")}

--- a/src/apps/related-materials/related-materials.dev.jsx
+++ b/src/apps/related-materials/related-materials.dev.jsx
@@ -31,7 +31,7 @@ export function Entry() {
       )}
       coverServiceUrl={text(
         "Cover Service URL",
-        "https://cover.dandigbib.org/api"
+        "https://cover.dandigbib.org/api/v2"
       )}
       titleText={text("Title text", "Forslag")}
       searchText={text("Search text", "Søg")}

--- a/src/apps/related-materials/related-materials.jsx
+++ b/src/apps/related-materials/related-materials.jsx
@@ -56,6 +56,7 @@ RelatedMaterial.propTypes = {
     imageUrls: PropTypes.shape({
       // We currently only use the large size for displaying related materials.
       large: PropTypes.shape({
+        url: urlPropType,
         format: PropTypes.oneOf(["png", "jpeg"]),
         size: PropTypes.oneOf([
           "original",

--- a/src/apps/related-materials/related-materials.jsx
+++ b/src/apps/related-materials/related-materials.jsx
@@ -22,7 +22,7 @@ function RelatedMaterial({
   materialUrl
 }) {
   const [imageStatus, setImageStatus] = useState("initial");
-  const coverUrl = cover.imageUrls.find(url => url.size === "large").url;
+  const coverUrl = cover.imageUrls.large.url;
   const formattedCreators = creators.join(", ");
   const alt = `${type} - ${formattedCreators}: ${title} (${year})`;
   return (
@@ -53,8 +53,9 @@ RelatedMaterial.propTypes = {
   year: PropTypes.string.isRequired,
   cover: PropTypes.shape({
     id: PropTypes.string,
-    imageUrls: PropTypes.arrayOf(
-      PropTypes.shape({
+    imageUrls: PropTypes.shape({
+      // We currently only use the large size for displaying related materials.
+      large: PropTypes.shape({
         format: PropTypes.oneOf(["png", "jpeg"]),
         size: PropTypes.oneOf([
           "original",
@@ -64,7 +65,7 @@ RelatedMaterial.propTypes = {
           "large"
         ])
       })
-    ),
+    }),
     type: PropTypes.oneOf(["pid"])
   }).isRequired,
   materialUrl: urlPropType.isRequired

--- a/src/apps/related-materials/related-materials.test.js
+++ b/src/apps/related-materials/related-materials.test.js
@@ -91,122 +91,122 @@ function getCover(amount = 10) {
     {
       id: "870970-basis:47664705",
       type: "pid",
-      imageUrls: [
-        {
+      imageUrls: {
+        large: {
           url:
             "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1580475253/bogportalen.dk/9788772143804.jpg",
           format: "jpeg",
           size: "large"
         }
-      ]
+      }
     },
     {
       id: "870970-basis:46365674",
       type: "pid",
-      imageUrls: [
-        {
+      imageUrls: {
+        large: {
           url:
             "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1575217601/bogportalen.dk/9788762731103.jpg",
           format: "jpeg",
           size: "large"
         }
-      ]
+      }
     },
     {
       id: "870970-basis:47714168",
       type: "pid",
-      imageUrls: [
-        {
+      imageUrls: {
+        large: {
           url:
             "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1580477087/bogportalen.dk/9788772053264.jpg",
           format: "jpeg",
           size: "large"
         }
-      ]
+      }
     },
     {
       id: "870970-basis:47248655",
       type: "pid",
-      imageUrls: [
-        {
+      imageUrls: {
+        large: {
           url:
             "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1575214321/bogportalen.dk/9788741508146.jpg",
           format: "jpeg",
           size: "large"
         }
-      ]
+      }
     },
     {
       id: "870970-basis:47593638",
       type: "pid",
-      imageUrls: [
-        {
+      imageUrls: {
+        large: {
           url:
             "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1580478413/bogportalen.dk/9788702264524.jpg",
           format: "jpeg",
           size: "large"
         }
-      ]
+      }
     },
     {
       id: "870970-basis:47679907",
       type: "pid",
-      imageUrls: [
-        {
+      imageUrls: {
+        large: {
           url:
             "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1580475188/bogportalen.dk/9788740661279.jpg",
           format: "jpeg",
           size: "large"
         }
-      ]
+      }
     },
     {
       id: "870970-basis:47450527",
       type: "pid",
-      imageUrls: [
-        {
+      imageUrls: {
+        large: {
           url:
             "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1575214074/bogportalen.dk/9788793728233.jpg",
           format: "jpeg",
           size: "large"
         }
-      ]
+      }
     },
     {
       id: "870970-basis:47811406",
       type: "pid",
-      imageUrls: [
-        {
+      imageUrls: {
+        large: {
           url:
             "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1580475133/bogportalen.dk/9788741510415.jpg",
           format: "jpeg",
           size: "large"
         }
-      ]
+      }
     },
     {
       id: "870970-basis:47661927",
       type: "pid",
-      imageUrls: [
-        {
+      imageUrls: {
+        large: {
           url:
             "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1580476960/bogportalen.dk/9788772187471.jpg",
           format: "jpeg",
           size: "large"
         }
-      ]
+      }
     },
     {
       id: "870970-basis:47806119",
       type: "pid",
-      imageUrls: [
-        {
+      imageUrls: {
+        large: {
           url:
             "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1580475217/bogportalen.dk/9788758836713.jpg",
           format: "jpeg",
           size: "large"
         }
-      ]
+      }
     }
   ].slice(0, amount);
 }
@@ -255,7 +255,7 @@ describe("Related Materials", () => {
     });
     cy.route({
       method: "GET",
-      url: "https://cover.dandigbib.org/api/cover/pid*",
+      url: "https://cover.dandigbib.org/api/v2/covers*",
       status: 200,
       response: getCover(10)
     });
@@ -281,7 +281,7 @@ describe("Related Materials", () => {
     // Only returns 5 covers
     cy.route({
       method: "GET",
-      url: "https://cover.dandigbib.org/api/cover/pid*",
+      url: "https://cover.dandigbib.org/api/v2/covers*",
       status: 200,
       response: getCover(5)
     });
@@ -307,7 +307,7 @@ describe("Related Materials", () => {
 
     cy.route({
       method: "GET",
-      url: "https://cover.dandigbib.org/api/cover/pid*",
+      url: "https://cover.dandigbib.org/api/v2/covers*",
       status: 400,
       response: {
         type: "https://tools.ietf.org/html/rfc2616#section-10",

--- a/src/components/cover/cover.jsx
+++ b/src/components/cover/cover.jsx
@@ -25,21 +25,17 @@ export const COVER_INITIAL = "initial";
  * @export
  * @param {object} options
  * @param {string} options.id
- * @param {string} options.format
  * @param {('default'|'small'|'medium'|'large'|'original')}  options.size
  * @param {string} options.idType
- * @param {boolean} options.generic
  * @param {string} options.coverServiceUrl
  *
  * @returns Cover
  */
 export function useCover({
   id,
-  format = "jpeg",
   size = "default",
   idType = "pid",
-  generic = false,
-  coverServiceUrl = "https://cover.dandigbib.org/api"
+  coverServiceUrl = "https://cover.dandigbib.org/api/v2"
 }) {
   const [status, setStatus] = useState({ status: COVER_INITIAL });
   useEffect(() => {
@@ -47,13 +43,13 @@ export function useCover({
       baseUrl: coverServiceUrl
     });
     coverClient
-      .getCover({ id, size: [size], format: [format], idType, generic })
-      .then(cover => {
-        const url = cover?.imageUrls?.[0]?.url;
+      .getCover({ id, size: [size], idType })
+      .then(covers => {
+        const url = covers?.[0]?.imageUrls?.[size]?.url;
         setStatus({ status: url ? COVER_RETRIEVED : COVER_EMPTY, url });
       })
       .catch(() => setStatus({ status: COVER_EMPTY }));
-  }, [id, format, size, idType, generic, coverServiceUrl]);
+  }, [id, size, idType, coverServiceUrl]);
   return status || { status: COVER_EMPTY };
 }
 

--- a/src/components/cover/cover.jsx
+++ b/src/components/cover/cover.jsx
@@ -86,7 +86,7 @@ function Cover({ status, src, alt, coverClassName, className }) {
 
 Cover.defaultProps = {
   status: "initial",
-  src: "",
+  src: null,
   coverClassName: "",
   className: ""
 };

--- a/src/components/simple-material/simple-material.dev.jsx
+++ b/src/components/simple-material/simple-material.dev.jsx
@@ -32,7 +32,7 @@ export function Base() {
       )}
       coverServiceUrl={text(
         "Cover Service URL",
-        "https://cover.dandigbib.org/api"
+        "https://cover.dandigbib.org/api/v2"
       )}
     />
   );


### PR DESCRIPTION
Version 2 introduces a number of changes:

- The service has a single endpoint for serving one or more
covers
- Arguments for format and generic are no longer supported and thus
removed
- Arguments for id and size have been renamed and updated accordingly
- The return value is always an array of cover data where each cover
is keyed by size

Version 2 also requires authentication based on tokens from
Adgangsplatformen but we actually already provide this in the current
form so no changes are needed in that regard.

Update code, docblocks and tests accordingly.

Also add a bit of cleanup while we are at it:
- Add url proptype for related material covers
- Avoid prop type error when a cover does not have a source