### PR TITLE
Exclude materials with too small covers from Related Materials app

### DIFF
--- a/src/apps/related-materials/related-materials.entry.jsx
+++ b/src/apps/related-materials/related-materials.entry.jsx
@@ -41,10 +41,14 @@ async function getRelatedMaterials({
     sort
   });
   const materialIds = materials.map(material => material.pid[0]);
-  const covers = await coverClient.getCover({
+  // This fits our desired cover size the best.
+  const coverSize = "large";
+  const coverData = await coverClient.getCover({
     id: materialIds,
-    size: ["large"] // This fits our desired cover size the best.
+    size: [coverSize]
   });
+  // Remove covers which do not have the requested cover size.
+  const covers = coverData.filter(cover => cover.imageUrls[coverSize]?.url);
 
   function mergeCoverAndMaterials(cover) {
     function locateCoverMaterial(material) {

--- a/src/apps/related-materials/related-materials.test.js
+++ b/src/apps/related-materials/related-materials.test.js
@@ -290,6 +290,40 @@ describe("Related Materials", () => {
     cy.get(".ddb-related-material__skeleton").should("have.length", 5);
   });
 
+  it("Should not show covers without image urls", () => {
+    cy.server();
+    cy.route({
+      method: "GET",
+      url: "https://openplatform.dbc.dk/v3/search*",
+
+      status: 200,
+      response: {
+        statusCode: 200,
+        data: getWork(12),
+        hitCount: 2826,
+        more: true
+      }
+    });
+
+    // Make one cover behave as if no image existed for the large size with
+    // is used by the app.
+    function withNullCover(covers) {
+      const nullCover = covers.shift();
+      nullCover.imageUrls.large.url = null;
+      return [nullCover, ...covers];
+    }
+
+    cy.route({
+      method: "GET",
+      url: "https://cover.dandigbib.org/api/v2/covers*",
+      status: 200,
+      response: withNullCover(getCover(11))
+    });
+    cy.visit("/iframe.html?id=apps-related-materials--entry");
+    cy.get("a.ddb-related-material").should("have.length", 10);
+    cy.get(".ddb-related-material img:not([src])").should("have.length", 0);
+  });
+
   it("Should show a blank screen on failure", () => {
     cy.server();
     cy.route({

--- a/src/core/CoverService.js
+++ b/src/core/CoverService.js
@@ -20,7 +20,8 @@ class CoverService {
 
   /**
    * @typedef {Object} ImageUrl
-   * @property {string} url - The url for the image
+   * @property {?string} url - The url for the image.
+   *   Null if the requested size is larger than the original.
    * @property {string} format - The format of the image
    * @property {string} size - The size of the image
    */


### PR DESCRIPTION
We require a certain size of the cover images we retrieve. If the 
image is not large enough it may not display right on certain
devices. Consequently they should be removed for now.

Without this a related material will have a cover image with null as
src. This is just displayed as a blank space.

For good measure we also update the JSDoc to show that the url can
be null.

### Before

![Apps | Related materials - Entry ⋅ Storybook 2020-07-05 22-21-41](https://user-images.githubusercontent.com/73966/86541529-ea068f80-bf0d-11ea-9c32-a249643d85d2.png)

### After

![Apps | Related materials - Entry ⋅ Storybook 2020-07-05 22-21-17](https://user-images.githubusercontent.com/73966/86541520-da874680-bf0d-11ea-99b3-a1bb3ba5171b.png)
