### PR TITLE
Exclude clauses with empty data when searching for related materials

### DIFF
--- a/src/apps/related-materials/related-materials.entry.jsx
+++ b/src/apps/related-materials/related-materials.entry.jsx
@@ -171,11 +171,28 @@ function RelatedMaterialsEntry({
   maxTries
 }) {
   const coverClient = new CoverService({ baseUrl: coverServiceUrl });
-  const subject = `term.subject any "${subjects}"`;
-  const category = `term.category any "${categories}"`;
-  const source = `term.acSource any "${sources}"`;
-  const excludeTitle = `phrase.title="${rawExcludeTitle}"`;
-  const query = `${subject} and ${category} and ${source} not ${excludeTitle}`;
+
+  // We may be passed empty strings which will lead to an invalid query.
+  // Compile query clauses using only arguments with actual values.
+  const includes = [];
+  if (subjects) {
+    includes.push(`term.subject any "${subjects}"`);
+  }
+  if (categories) {
+    includes.push(`term.category any "${categories}"`);
+  }
+  if (sources) {
+    includes.push(`term.acSource any "${sources}"`);
+  }
+  const excludes = [];
+  if (rawExcludeTitle) {
+    excludes.push(`not phrase.title="${rawExcludeTitle}"`);
+  }
+
+  // Use join to get spacing between clauses right. Includes must be separated
+  // by "and" while excludes must nut. Excludes should already have "not" prepended.
+  const query = [includes.join(" and "), excludes.join(" ")].join(" ");
+
   const searchUrl = `${replacePlaceholders({
     text: rawSearchUrl,
     placeholders: {
@@ -183,6 +200,7 @@ function RelatedMaterialsEntry({
       sort: encodeURI(sort)
     }
   })}`;
+
   const relatedMaterials = useGetRelatedMaterials({
     query,
     fields: [


### PR DESCRIPTION
Properties with empty strings can lead to queries with clauses such 
as ‘term.subject any “”’. This is invalid and will lead to an error
response.

Instead we only generate clauses for nonempty properties and
assemble and query this from this.