### PR TITLE
Return related materials ordered by query instead of covers

### DIFF
--- a/src/apps/related-materials/related-materials.entry.jsx
+++ b/src/apps/related-materials/related-materials.entry.jsx
@@ -50,16 +50,17 @@ async function getRelatedMaterials({
   // Remove covers which do not have the requested cover size.
   const covers = coverData.filter(cover => cover.imageUrls[coverSize]?.url);
 
-  function mergeCoverAndMaterials(cover) {
-    function locateCoverMaterial(material) {
+  function mergeMaterialsAndCovers(material) {
+    function locateMaterialCover(cover) {
       return material.pid[0] === cover.id;
     }
-    const material = materials.find(locateCoverMaterial);
+    const cover = covers.find(locateMaterialCover);
     return { ...Material.format(material), cover };
   }
 
-  const coveredMaterials = covers.map(mergeCoverAndMaterials);
-  return coveredMaterials;
+  const coveredMaterials = materials.map(mergeMaterialsAndCovers);
+  // Remove materials without covers.
+  return coveredMaterials.filter(material => material.cover);
 }
 
 /**


### PR DESCRIPTION
In the current version we retrieve object ids from search result,
pass these to the cover service in the same order and merge material 
data intro the provided results.

However practice has shown that the cover service does not
necessarily preserve the order of the requested ids in the response.
This leads to a situation where the related materials will not have
the same order as in the linked search result. 

To preserve the order of the materials from the search result we 
merge cover data into the materials instead and filter away any 
materials without a cover.