### PR TITLE
Improve handling of related materialers with limited results

### DIFF
--- a/src/apps/related-materials/related-materials.entry.jsx
+++ b/src/apps/related-materials/related-materials.entry.jsx
@@ -264,7 +264,7 @@ RelatedMaterialsEntry.propTypes = {
 
 RelatedMaterialsEntry.defaultProps = {
   amount: 10,
-  maxTries: 20,
+  maxTries: 5,
   titleText: "Forslag med samme emner",
   searchText: "Søg på samme emner",
   sort: "date_descending"

--- a/src/apps/related-materials/related-materials.entry.jsx
+++ b/src/apps/related-materials/related-materials.entry.jsx
@@ -108,7 +108,7 @@ function useGetRelatedMaterials({
       const calculatedLimit = Math.ceil(
         missing * (relatedMaterials.tries + 1) * aggressiveOverhead
       );
-      const limit = Math.max(calculatedLimit, maxLimit);
+      const limit = Math.min(calculatedLimit, maxLimit);
       getRelatedMaterials({
         query,
         limit,

--- a/src/apps/related-materials/related-materials.test.js
+++ b/src/apps/related-materials/related-materials.test.js
@@ -83,7 +83,7 @@ function getWork(amount = 12) {
       typeBibDKType: ["Lydbog (net)"],
       date: ["2020"]
     }
-  ].slice(0, amount - 1);
+  ].slice(0, amount);
 }
 
 function getCover(amount = 10) {
@@ -333,7 +333,7 @@ describe("Related Materials", () => {
       status: 200,
       response: {
         statusCode: 200,
-        data: [],
+        data: getWork(1),
         hitCount: 2826,
         more: true
       }

--- a/src/core/CoverService.js
+++ b/src/core/CoverService.js
@@ -49,6 +49,12 @@ class CoverService {
       throw Error("id must be specified");
     }
     const ids = Array.isArray(id) ? id : [id];
+    if (ids.length === 0) {
+      // Only try to retrieve covers if provided with actual ids. The Cover
+      // service fails if requested without any ids.
+      return [];
+    }
+
     const base = `${this.baseUrl}/covers`;
     const withId = `${base}?type=${idType}&identifiers=${ids
       .map(encodeURIComponent)


### PR DESCRIPTION
In the current form if the search request returns an empty set of ids we do not need to retrieve covers.

The service fails with HTTP status code 400 otherwise.

If the client is requested with an empty set of ids we can also 
safely return an empty array as a response.

Also since the component will retry we also have to adjust how it determines the increasing number of requests. Instead of the limit of 50 being the minimum number of results to retrieve it has to be the maximum. Otherwise the service will return an error response.