### PR TITLE
Improve query generation for related materials

### DIFF
--- a/src/apps/related-materials/related-materials.dev.jsx
+++ b/src/apps/related-materials/related-materials.dev.jsx
@@ -11,15 +11,21 @@ export default {
 export function Entry() {
   return (
     <RelatedMaterialsEntry
-      subjects={text("Subjects to include in search", "magi troldmænd")}
-      categories={text("Categories to include in search", "børnematerialer")}
+      subjects={text(
+        "Subjects to include in search (separate by ,)",
+        "magi,troldmænd"
+      )}
+      categories={text(
+        "Categories to include in search (separate by ,)",
+        "børnematerialer"
+      )}
       sources={text(
-        "Sources to include in search",
-        "bibliotekskatalog 'ereolen' 'ereolen global' 'comics plus' 'ebook central' 'rbdigital magazines'"
+        "Sources to include in search (separate by ,)",
+        "bibliotekskatalog,ereolen,ereolen global,comics plus,ebook central,rbdigital magazines"
       )}
       excludeTitle={text(
         "Title not to include",
-        "'harry potter og fønixordenen'"
+        "harry potter og fønixordenen"
       )}
       searchUrl={text(
         "Search URL",


### PR DESCRIPTION
The current query does not sufficiently handle phrases and multiple
values. Consequently we have to update it for more advanced query
building.

We now use , as a separator between parts of a strong instead of 
passing the string directly to the query.

Update our storybook with more elaborate field titles and example
values that fit the updated pattern accordingly.