### PR TITLE
Do not render component if there are no related materials to show

### DIFF
--- a/src/apps/related-materials/related-materials.entry.jsx
+++ b/src/apps/related-materials/related-materials.entry.jsx
@@ -137,9 +137,11 @@ function useGetRelatedMaterials({
           const finishedMaterials =
             related?.filter(material => material.data)?.length || 0;
           const tries = relatedMaterials.tries + 1;
+          // If we have no materials to show then finish using the empty state.
+          const endStatus = finishedMaterials > 0 ? "finished" : "empty";
           const status =
             finishedMaterials >= amount || tries >= maxTries
-              ? "finished"
+              ? endStatus
               : "processing";
           setRelatedMaterials({
             status,

--- a/src/apps/related-materials/related-materials.jsx
+++ b/src/apps/related-materials/related-materials.jsx
@@ -80,10 +80,13 @@ function RelatedMaterials({
   searchText,
   titleText
 }) {
-  if (status === "failed") {
-    // We fail discretly since there is no use in showing links or anything since the fail
-    // would mean a lack of works/materials.
+  if (status === "failed" || status === "empty") {
+    // Return discretly.
+    // When a failure occurs there is no use in showing links or anything since
+    // the fail would mean a lack of works/materials.
     // An actual unhandled failure would still result in our error boundary.
+    // At the moment we also do not render anything if there are no materials
+    // to show.
     return null;
   }
   return (


### PR DESCRIPTION
If we do not locate any related materials then our component will
show a title and a link after loading. That looks somewhat silly.

We do not have a proper way to handle this situation by providing a
message to the end user so instead we just hide the component by
not rendering anything.

To do this we introduce the new “empty” status and set this if we
are done loading but still have no related materials.