### PR TITLE
4886 only show local materials

### DIFF
--- a/scripts/docker-compose.sh
+++ b/scripts/docker-compose.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Fail if any command does.
+set -e
+
 OS=$(uname -s)
 
 if [ $OS = "Darwin" ]; then

--- a/src/apps/related-materials/related-materials.dev.jsx
+++ b/src/apps/related-materials/related-materials.dev.jsx
@@ -37,5 +37,6 @@ Entry.args = {
   titleText: "Forslag",
   searchText: "Søg",
   amount: 10,
-  maxTries: 5
+  maxTries: 5,
+  agencyId: "736000"
 };


### PR DESCRIPTION
Limit related materials to locally available. Implemented as optional so we don't break BC.

Also a fix for the bash script.
