### PR TITLE
Implement re-fetching when query changes.

### DIFF
--- a/src/apps/related-materials/related-materials.entry.jsx
+++ b/src/apps/related-materials/related-materials.entry.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import PropTypes from "prop-types";
 import urlPropType from "url-prop-type";
 import replace from "lodash/replace";
@@ -85,7 +85,7 @@ function useGetRelatedMaterials({
   sort,
   coverClient
 } = {}) {
-  const [relatedMaterials, setRelatedMaterials] = useState({
+  const initialState = useRef({
     status: "ready",
     tries: 0,
     offset: 0,
@@ -94,6 +94,14 @@ function useGetRelatedMaterials({
       data: undefined
     }))
   });
+
+  const [relatedMaterials, setRelatedMaterials] = useState({});
+
+  // Whenever the query changes we want to re-initialize the state and re-fetch new materials.
+  useEffect(() => {
+    setRelatedMaterials(initialState.current);
+  }, [initialState, query]);
+
   // This is the amount additional to the desired we want to try and fetch.
   // This is to ensure a better first hit in most instances.
   // The current overhead is based upon our own sampling.
@@ -160,7 +168,16 @@ function useGetRelatedMaterials({
           });
         });
     }
-  }, [amount, maxTries, relatedMaterials, query, fields, sort, coverClient]);
+  }, [
+    amount,
+    coverClient,
+    fields,
+    initialState,
+    maxTries,
+    query,
+    relatedMaterials,
+    sort
+  ]);
   return relatedMaterials;
 }
 


### PR DESCRIPTION
Beforehand we did not re-fetch any materials when the query changed.
This was not a problem since the RelatedMaterials app was being used
rather statically on the consumer side. A query was provided but never
changed. Therefore the initial fetch of materials was good enough.
The whistleblower is the StoryBook implementation. Here you can change
the query on a whim but in doing so the materials remain static and
nothing changes.

The reason for the current design was to fetch a partial result and
display it to the user whenever the first couple of materials became
available. This meant relying of state and useEffect as way of recursively
try to fetch the requested materials. If done internally in the fetch
we would not be able to display anything before the requested materials
all were present. This is, speaking crudely, our way of implementing a
stream of materials that get's shown the minute a subset is available.

The problem with this is that whenever props changes, such as the query,
we look to the state and see that we either have tried the maximum of
times we are allowed to try or that we have all the materials we need.
We can't really differ between the initial render and the subsequent.

The addition to the current implementation looks at the query for changes
in a seperate effect and reset the materials state which triggers the
other effect that recursively then begins fetching new materials with
the new query.