### PR TITLE
Use v3 for action building GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,12 +31,8 @@ jobs:
     - run: yarn install
 
     - run: yarn build:storybook
-
-    - run: touch ./dev/.nojekyll
-
-    - name: deploy
-      uses: peaceiris/actions-gh-pages@v2.5.0
-      env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./dev
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./dev


### PR DESCRIPTION
This allows us to [use the default `GITHUB_TOKEN`](https://github.com/peaceiris/actions-gh-pages#supported-tokens) instead of a specific
secret. This makes it easier to use the workflow across forks as they
do not have to setup their own secrets. 

[The newer version also disables Jekyll by default](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-enable-built-in-jekyll-enable_jekyll) so we no longer 
have to touch ./dev/.nojekyll to achieve this.

[`gh-pages` is the default branch for GitHub Pages](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-another-github-pages-branch-publish_branch) so there is no reason
to specify this variable explicitly.