### PR TITLE
Also use Cypress action v2 for code coverage generation

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Cypress run
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v2
         with:
           start: yarn start:storybook:test
           wait-on: 'http://localhost:57021'


### PR DESCRIPTION
Version 1 uses obsolete GitHub Actions syntax. 

This causes [our builds on the master branch to fail](https://github.com/danskernesdigitalebibliotek/ddb-react/actions/runs/426688904). This has 
previously been fixed on other workflows in #120  but has probably gone 
unnoticed since build results on the master branch do not surface as
easily.