### PR TITLE
Replace ::add-path:: with $GITHUB_PATH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           curl --fail --silent --location --output ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/v0.13.0/ghr_v0.13.0_linux_amd64.tar.gz
           tar -zxf ghr.tar.gz
-          echo "::add-path::./ghr_v0.13.0_linux_amd64"
+          echo "./ghr_v0.13.0_linux_amd64" >> $GITHUB_PATH
       - name: Create release with asset
         if: startsWith(github.ref, 'refs/tags/')
         env:


### PR DESCRIPTION
[::add-path:: has been deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) for some time and is [now no longer
working](https://github.com/danskernesdigitalebibliotek/ddb-react/actions/runs/530883493).