### PR TITLE
Use fan-out architecture when building pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,29 +4,36 @@ on: pull_request
 
 jobs:
 
-  stylelint:
-    name: Lint .scss
+  install:
+    name: Install dependencies
     if: '!github.event.deleted'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+        with:
+          # Required to fetch all commits and tags
+          fetch-depth: 0
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+      - name: Store build
+        uses: actions/upload-artifact@v2
+        with:
+          name: install
+          path: .
+
+  stylelint:
+    name: Lint .scss
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Download files
+        uses: actions/download-artifact@v2
+        with:
+          name: build
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.13.0'
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Install Dependencies
-        run: yarn install
-
+          node-version: '12'
       - name: stylelint
         uses: reviewdog/action-stylelint@v1
         with:
@@ -40,25 +47,16 @@ jobs:
     name: Lint .js and .jsx
     if: '!github.event.deleted'
     runs-on: ubuntu-latest
+    needs: install
     steps:
-      - uses: actions/checkout@master
+      - name: Download files
+        uses: actions/download-artifact@v2
+        with:
+          name: build
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.13.0'
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Install Dependencies
-        run: yarn install
-
+          node-version: '12'
       - name: eslint
         uses: reviewdog/action-eslint@v1
         with:
@@ -72,24 +70,16 @@ jobs:
     name: Integration test
     if: '!github.event.deleted'
     runs-on: ubuntu-16.04
+    needs: install
     steps:
-      - uses: actions/checkout@master
+      - name: Download files
+        uses: actions/download-artifact@v2
+        with:
+          name: build
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.13.0'
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Install Dependencies
-        run: yarn install
+          node-version: '12'
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
@@ -118,13 +108,16 @@ jobs:
     name: Build artifacts
     if: '!github.event.deleted'
     runs-on: ubuntu-latest
+    needs: install
     steps:
-      - uses: actions/checkout@v2
+      - name: Download files
+        uses: actions/download-artifact@v2
         with:
-          # Required to fetch all commits and tags
-          fetch-depth: 0
-      - name: Install Dependencies
-        run: yarn install
+          name: build
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
       - name: Build artifacts
         run: |
           VERSION_FILE_NAME=$GITHUB_REPOSITORY \


### PR DESCRIPTION
Fetching dependencies is by far the most time consuming proces when
building. With this approach we only have to do it once.

Then we can let each tool download the result as an artifact and run
its own course.

bahmutov/npm-install is simpler than having to manage cache ourselves
and built by a developer we trust since he is also the lead of
Cypress.