### PR TITLE
Don't use advanced regex not supported by Safari

### DIFF
--- a/src/apps/related-materials/related-materials.entry.jsx
+++ b/src/apps/related-materials/related-materials.entry.jsx
@@ -196,7 +196,7 @@ function useGetRelatedMaterials({
 function stringToArray(string) {
   // Replace escaped commas with newlines (which doesn't make sense in a comma
   // separated string) so we wont split on them.
-  const unescapedParts = replace(string, "\\,", "\n").split(/(?<!\\),/);
+  const unescapedParts = replace(string, "\\,", "\n").split(/,/);
   const escapedParts = unescapedParts.map(part => replace(part, "\n", ","));
   // Remove leading and trailing spaces and empty values.
   const trimmedParts = escapedParts.map(part => part.trim());


### PR DESCRIPTION
The zero-width negative lookbehind assertion isn't supported by
Safari (and likely IE/Edge).

The previous fix for this did not actually remove the zero-width 
negative lookbehind. Consequently we do it now.

Originally the purpose of it was to avoid splitting a string on
escaped characters. However this is already handled by replacing 
escaped characters by newlines, splitting along unescaped characters 
and finally replacing newlines with unescaped characters.

Consequently we can just drop the advanced regex entirely.

Ref #4922