### PR TITLE
Use init in node container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
-version: '3'
+version: '3.7'
 services:
   node:
     image: node:12.13.0-alpine
     user: node
+    init: true
     working_dir: /home/node/app
     volumes:
       - root:/home/node/app


### PR DESCRIPTION
Node isn't a proper init process, so it doesn't properly handle the
signals sent by the Docker daemon. This is especially noticeable when
stopping the container as Docker has to wait before forcibly killing
the process.

This fixes it by just telling Docker to use an init process.

Some background reading on the importance of an init process:

https://github.com/krallin/tini
https://github.com/Yelp/dumb-init#why-you-need-an-init-system