### PR TITLE
Run Cypress on GitHub Actions using latest version of Ubuntu

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,7 +71,7 @@ jobs:
   test:
     name: Integration test
     if: '!github.event.deleted'
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: Setup Node


### PR DESCRIPTION
[GitHub Actions have sunset support for 16.04](https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/). This is [causing
problems for our Cypress tests](https://github.com/danskernesdigitalebibliotek/ddb-react/runs/3995986303?check_suite_focus=true) which are currently locked to this
version.

Previously we locked the version to 16.04 due to compatibility
problems with Cypress which was locked to version 3.8.0 at that point
in time.

Subsequently we have updated to Cypress ^3.8.3. This new version also
fixed Ubuntu compatibility.

See cypress-io/github-action@1da4e03