### PR TITLE
Pin node version on GitHub Actions to v12

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -123,6 +123,10 @@ jobs:
         with:
           # Required to fetch all commits and tags
           fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.13.0'
       - name: Install Dependencies
         run: yarn install
       - name: Build artifacts
@@ -142,6 +146,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.13.0'
       - name: Install Dependencies
         run: yarn install
       - name: Build documentation


### PR DESCRIPTION
Some actions are not pinned to a specific version of Node and
consequently use the version provided by the operating system.

Recently GitHub upgraded their runners to Ubuntu 20 which has
Node 16. Parts of our system is not compatible with Node 16 -
primarily the version of node-sass that we use.

This causes our build to fail.

To address this we have to ensure that all jobs use the same version.

The version that we currently use across the project is 12.13.0 so
use that as well.

Later on we should upgrade to a newer version of Node.